### PR TITLE
Allow checking out remote branches from the commit list

### DIFF
--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -439,7 +439,7 @@ Branch Repository::createBranch(const QString &name, const Commit &target)
   emit d->notifier->referenceAboutToBeAdded(name);
 
   git_reference *ref = nullptr;
-  git_branch_create(&ref, d->repo, name.toUtf8(), commit, false);
+  git_branch_create(&ref, d->repo, name.toUtf8(), commit, true);
 
   // We have to notify even if creation failed and the branch is invalid.
   // Clients can check the argument to see if a branch was really added.

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1344,6 +1344,8 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event)
 
   QMenu menu;
 
+  menu.setToolTipsVisible(true);
+
   // stash
   git::Reference ref = static_cast<CommitModel *>(mModel)->reference();
   if (ref.isValid() && ref.isStash()) {
@@ -1440,6 +1442,27 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event)
             head.isValid() &&
             head.qualifiedName() != ref.qualifiedName() &&
             !view->repo().isBare());
+        }
+        if (ref.isRemoteBranch()) {
+          QAction *checkout = menu.addAction(tr("Checkout %1").arg(ref.name()),
+          [view, ref] {
+              view->checkout(ref);
+          });
+
+          QString disableTooltip;
+
+          // Calculate local branch name in the same way as checkout() does
+          QString local = ref.name().section('/', 1);
+
+          if (!head.isValid()) // I'm not sure when this can happen
+            disableTooltip = "";
+          if (head.name() == local)
+            disableTooltip = "Local branch is already checked out";
+          if (view->repo().isBare())
+            disableTooltip = "This is a bare repository";
+
+          checkout->setToolTip(disableTooltip);
+          checkout->setEnabled(disableTooltip.isNull());
         }
       }
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1833,6 +1833,34 @@ void RepoView::checkout(
     return;
   }
 
+  if (ref.isRemoteBranch() && mRepo.lookupBranch(local, GIT_BRANCH_LOCAL)) {
+
+    QString title = tr("Overwrite local branch?");
+    QString text =
+      tr("There is already a local branch called '%1'. Do you want to reset "
+         "that branch to this commit or do you want to check out a detached "
+         "head from this commit?");
+    QMessageBox *dialog = new QMessageBox(
+      QMessageBox::Question, title, text.arg(local),
+      QMessageBox::Cancel, this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+    QPushButton *createButton =
+      dialog->addButton(tr("Reset local branch"), QMessageBox::AcceptRole);
+    connect(createButton, &QPushButton::clicked, [this, ref, local] {
+      createBranch(local, ref.target(), ref, true);
+    });
+
+    QPushButton *checkoutButton =
+      dialog->addButton(tr("Checkout detached head"), QMessageBox::DestructiveRole);
+    connect(checkoutButton, &QPushButton::clicked, [this, ref, detach] {
+      checkout(ref.target(), ref, detach);
+    });
+
+    dialog->open();
+    return;
+  }
+
   checkout(ref.target(), ref, detach);
 }
 


### PR DESCRIPTION
This commit allows to check out remote branches from the context menu
of a commit:

![image](https://user-images.githubusercontent.com/1188538/52893758-64f7ca80-31a0-11e9-8fd1-78695ac0a0ad.png)

... if the respective local branch isn't already checked out, in which case Reset could be used:

![image](https://user-images.githubusercontent.com/1188538/52893756-56a9ae80-31a0-11e9-87ae-f8862d70863c.png)

When checking out a remote branch and a local branch of the same name
already exists, a dialog is shown that offers the choice between
resetting the existing branch to that commit and checking out a detached
head:

![image](https://user-images.githubusercontent.com/1188538/52893772-83f65c80-31a0-11e9-8d31-c85de2d07854.png)
