### PR TITLE
Remember previously opened repository path and use when finding new.

### DIFF
--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -27,6 +27,7 @@ const QStandardPaths::StandardLocation kUserLocation =
   QStandardPaths::AppLocalDataLocation;
 
 const QString kIgnoreWsKey = "diff/whitespace/ignore";
+const QString kLastPathKey = "lastpath";
 
 // Look up variant at key relative to root.
 QVariant lookup(const QVariantMap &root, const QString &key)
@@ -77,6 +78,7 @@ Settings::Settings(QObject *parent)
 {
   foreach (const QFileInfo &file, confDir().entryInfoList(QStringList("*.lua")))
     mDefaults[file.baseName()] = ConfFile(file.absoluteFilePath()).parse();
+  mDefaults[kLastPathKey] = QDir::homePath();
   mCurrentMap = mDefaults;
 }
 
@@ -207,6 +209,16 @@ bool Settings::isWhitespaceIgnored() const
 void Settings::setWhitespaceIgnored(bool ignored)
 {
   setValue(kIgnoreWsKey, ignored, true);
+}
+
+QString Settings::lastPath() const
+{
+  return value(kLastPathKey).toString();
+}
+
+void Settings::setLastPath(const QString &lastPath)
+{
+  setValue(kLastPathKey, lastPath);
 }
 
 QDir Settings::appDir()

--- a/src/conf/Settings.h
+++ b/src/conf/Settings.h
@@ -48,6 +48,10 @@ public:
   bool isWhitespaceIgnored() const;
   void setWhitespaceIgnored(bool ignored);
 
+  // Last repository path
+  QString lastPath() const;
+  void setLastPath(const QString &lastPath);
+
   // settings directories
   static QDir appDir();
   static QDir docDir();

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -109,10 +109,12 @@ MenuBar::MenuBar(QWidget *parent)
   open->setShortcut(QKeySequence::Open);
   connect(open, &QAction::triggered, [] {
     // FIXME: Filter out non-git dirs.
-    QString home = QDir::homePath();
+    Settings *settings = Settings::instance();
     QString title = tr("Open Repository");
-    MainWindow::open(QFileDialog::getExistingDirectory(
-      nullptr, title, home, QFileDialog::ShowDirsOnly));
+    QString path = QFileDialog::getExistingDirectory(
+      nullptr, title, settings->lastPath(), QFileDialog::ShowDirsOnly);
+    MainWindow::open(path);
+    settings->setLastPath(path);
   });
 
   QMenu *openRecent = file->addMenu(tr("Open Recent"));


### PR DESCRIPTION
In order to fix issue #185 (partially) remember the path used to
open new repositories to give to QFileDialog to open subsequent
repositories.

TODO: Maybe the path should be saved to settings and loaded on
application start also so it's not just per run of the application.
Also this doesn't get initialized on application startup if
Application::restoreWindows opens a repository. Maybe MainWindow
should have a signal when it successfully opens a git repository
so MenuBar can update this path?