### PR TITLE
option to ignore untracked files

### DIFF
--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -27,6 +27,7 @@ const QStandardPaths::StandardLocation kUserLocation =
   QStandardPaths::AppLocalDataLocation;
 
 const QString kIgnoreWsKey = "diff/whitespace/ignore";
+const QString kIncludeUtKey = "diff/untracked/include";
 const QString kLastPathKey = "lastpath";
 
 // Look up variant at key relative to root.
@@ -209,6 +210,16 @@ bool Settings::isWhitespaceIgnored() const
 void Settings::setWhitespaceIgnored(bool ignored)
 {
   setValue(kIgnoreWsKey, ignored, true);
+}
+
+bool Settings::isUntrackedIncluded() const
+{
+  return value(kIncludeUtKey).toBool();
+}
+
+void Settings::setUntrackedIncluded(bool included)
+{
+  setValue(kIncludeUtKey, included, true);
 }
 
 QString Settings::lastPath() const

--- a/src/conf/Settings.h
+++ b/src/conf/Settings.h
@@ -47,6 +47,10 @@ public:
   // ignore whitespace
   bool isWhitespaceIgnored() const;
   void setWhitespaceIgnored(bool ignored);
+  
+  // include untracked files
+  bool isUntrackedIncluded() const;
+  void setUntrackedIncluded(bool included);
 
   // Last repository path
   QString lastPath() const;

--- a/src/dialogs/DiffPanel.cpp
+++ b/src/dialogs/DiffPanel.cpp
@@ -85,6 +85,13 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
   connect(ignoreWs, &QCheckBox::toggled, [](bool checked) {
     Settings::instance()->setWhitespaceIgnored(checked);
   });
+  
+  // including untracked files
+  QCheckBox *includeUt = new QCheckBox(tr("Include untracked files"), this);
+  includeUt->setChecked(Settings::instance()->isUntrackedIncluded());
+  connect(includeUt, &QCheckBox::toggled, [](bool checked) {
+    Settings::instance()->setUntrackedIncluded(checked);
+  });
 
   // auto collapse
   Settings *settings = Settings::instance();
@@ -99,8 +106,11 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
   connect(collapseDeleted, &QCheckBox::toggled, [settings](bool checked) {
     settings->setValue("collapse/deleted", checked);
   });
+  
+  
 
   layout->addRow(tr("Whitespace:"), ignoreWs);
+  layout->addRow(tr("Untracked files:"), includeUt);
   layout->addRow(tr("Auto Collapse:"), collapseAdded);
   layout->addRow(QString(), collapseDeleted);
 }

--- a/src/git/Index.cpp
+++ b/src/git/Index.cpp
@@ -116,7 +116,7 @@ Index::StagedState Index::isStaged(const QString &path) const
 
   // Handle untracked directories.
   QFileInfo info(repo.workdir().filePath(path));
-  if (!sm.isValid() && !info.isSymLink() && info.isDir())
+  if (!sm.isValid() && !info.isSymLink() && info.isDir() || !isTracked(path))
     return d->stagedCache.insert(path, Unstaged).value();
 
   uint32_t headMode = GIT_FILEMODE_UNREADABLE;

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -311,7 +311,7 @@ Diff Repository::diffTreeToIndex(
   const Index &index) const
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  if (Settings::instance()->isUntrackedIncluded())
+  if (appConfig().value<bool>("untracked.include", Settings::instance()->isUntrackedIncluded()))
     opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
   if (Settings::instance()->isWhitespaceIgnored())
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
@@ -327,7 +327,7 @@ Diff Repository::diffIndexToWorkdir(
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
   opts.flags |= (GIT_DIFF_DISABLE_MMAP);
-  if (Settings::instance()->isUntrackedIncluded())
+  if (appConfig().value<bool>("untracked.include", Settings::instance()->isUntrackedIncluded()))
     opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
   if (Settings::instance()->isWhitespaceIgnored())
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -311,7 +311,8 @@ Diff Repository::diffTreeToIndex(
   const Index &index) const
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
+  if (Settings::instance()->isUntrackedIncluded())
+    opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
   if (Settings::instance()->isWhitespaceIgnored())
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 
@@ -325,7 +326,9 @@ Diff Repository::diffIndexToWorkdir(
   Diff::Callbacks *callbacks) const
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= (GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_DISABLE_MMAP);
+  opts.flags |= (GIT_DIFF_DISABLE_MMAP);
+  if (Settings::instance()->isUntrackedIncluded())
+    opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
   if (Settings::instance()->isWhitespaceIgnored())
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1580,6 +1580,11 @@ class FileWidget : public QWidget
   Q_OBJECT
 
 public:
+    bool isBinary() const
+    {
+        return isReallyBinary;
+    }
+    
   class Header : public QFrame
   {
   public:
@@ -1825,16 +1830,17 @@ public:
     QString path = repo.workdir().filePath(name);
     bool submodule = repo.lookupSubmodule(name).isValid();
 
-    bool binary = patch.isBinary();
+    isReallyBinary = patch.isBinary();
     if (patch.isUntracked()) {
       QFile dev(path);
       if (dev.open(QFile::ReadOnly)) {
         QByteArray content = dev.read(1024);
         git::Buffer buffer(content.constData(), content.length());
-        binary = buffer.isBinary();
+        isReallyBinary = buffer.isBinary();
       }
     }
-
+    bool binary = isReallyBinary;
+    
     bool lfs = patch.isLfsPointer();
 
     mHeader = new Header(diff, patch, binary, lfs, submodule, parent);
@@ -2024,6 +2030,7 @@ private:
   Header *mHeader;
   QList<QWidget *> mImages;
   QList<HunkWidget *> mHunks;
+  bool isReallyBinary;
 };
 
 } // anon. namespace

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1606,7 +1606,13 @@ public:
       if (lineStats.additions > 0 || lineStats.deletions > 0)
         stats = new LineStats(lineStats, this);
 
-      FileLabel *label = new FileLabel(name, submodule, this);
+      QString displayname = QString(name);
+      if (binary) {
+          qint64 fsize = QFile(patch.repo().workdir().filePath(name)).size();
+          displayname += " (" + QString::number(fsize/1024) + " kB)";
+      }
+      
+      FileLabel *label = new FileLabel(displayname, submodule, this);
       if (patch.status() == GIT_DELTA_RENAMED)
         label->setOldName(patch.name(git::Diff::OldFile));
 

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1847,6 +1847,21 @@ public:
     layout->addWidget(mHeader);
 
     DisclosureButton *disclosureButton = mHeader->disclosureButton();
+    
+    // Start hidden when the file is checked or untracked
+    bool expand = (mHeader->check()->checkState() == Qt::Unchecked && !mPatch.isUntracked());
+
+    if (Settings::instance()->value("collapse/added").toBool() == true &&
+        patch.status() == GIT_DELTA_ADDED)
+      expand = false;
+
+    if (Settings::instance()->value("collapse/deleted").toBool() == true &&
+        patch.status() == GIT_DELTA_DELETED)
+      expand = false;
+
+    disclosureButton->setChecked(expand);
+
+    
     connect(disclosureButton, &DisclosureButton::toggled, [this](bool visible) {
 
       if (mHeader->lfsButton() && !visible) {
@@ -1925,19 +1940,6 @@ public:
         layout->addWidget(addImage(disclosureButton, mPatch, true));
       });
     }
-
-    // Start hidden when the file is checked.
-    bool expand = (mHeader->check()->checkState() == Qt::Unchecked);
-
-    if (Settings::instance()->value("collapse/added").toBool() == true &&
-        patch.status() == GIT_DELTA_ADDED)
-      expand = false;
-
-    if (Settings::instance()->value("collapse/deleted").toBool() == true &&
-        patch.status() == GIT_DELTA_DELETED)
-      expand = false;
-
-    disclosureButton->setChecked(expand);
   }
 
   bool isEmpty()

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1829,7 +1829,7 @@ public:
     if (patch.isUntracked()) {
       QFile dev(path);
       if (dev.open(QFile::ReadOnly)) {
-        QByteArray content = dev.readAll();
+        QByteArray content = dev.read(1024);
         git::Buffer buffer(content.constData(), content.length());
         binary = buffer.isBinary();
       }

--- a/src/ui/FileList.cpp
+++ b/src/ui/FileList.cpp
@@ -261,6 +261,13 @@ FileList::FileList(const git::Repository &repo, QWidget *parent)
   connect(mIgnoreWs, &QAction::triggered, [](bool checked) {
     Settings::instance()->setWhitespaceIgnored(checked);
   });
+  
+  mIncludeUt = menu->addAction(tr("Include untracked files"));
+  mIncludeUt->setCheckable(true);
+  mIncludeUt->setChecked(Settings::instance()->isUntrackedIncluded());
+  connect(mIncludeUt, &QAction::triggered, [](bool checked) {
+    Settings::instance()->setUntrackedIncluded(checked);
+  });
 
   connect(this, &FileList::doubleClicked, [this](const QModelIndex &index) {
     if (!index.isValid())

--- a/src/ui/FileList.cpp
+++ b/src/ui/FileList.cpp
@@ -17,6 +17,7 @@
 #include "git/Diff.h"
 #include "git/Patch.h"
 #include "git/Repository.h"
+#include "git/Config.h"
 #include "tools/ExternalTool.h"
 #include <QAbstractListModel>
 #include <QApplication>
@@ -264,10 +265,12 @@ FileList::FileList(const git::Repository &repo, QWidget *parent)
   
   mIncludeUt = menu->addAction(tr("Include untracked files"));
   mIncludeUt->setCheckable(true);
-  mIncludeUt->setChecked(Settings::instance()->isUntrackedIncluded());
-  connect(mIncludeUt, &QAction::triggered, [](bool checked) {
-    Settings::instance()->setUntrackedIncluded(checked);
-  });
+  mIncludeUt->setChecked(RepoView::parentView(parent)->repo().appConfig().value<bool>("untracked.include", Settings::instance()->isUntrackedIncluded()));
+  connect(mIncludeUt, &QAction::triggered, [parent, this](bool checked) {
+    RepoView *view = RepoView::parentView(this);
+    view->repo().appConfig().setValue("untracked.include", checked);
+    view->refresh();
+});
 
   connect(this, &FileList::doubleClicked, [this](const QModelIndex &index) {
     if (!index.isValid())

--- a/src/ui/FileList.h
+++ b/src/ui/FileList.h
@@ -53,6 +53,7 @@ private:
   QMenu *mSelectMenu;
   QMenu *mSortMenu;
   QAction *mIgnoreWs;
+  QAction *mIncludeUt;
   QModelIndex mPressedIndex;
   QToolButton *mButton;
 


### PR DESCRIPTION
This addresses my concern in #224.
This seems to work fine by me but should still be considered WIP as :

- I do not really have a good understanding of what I am doing with the options
- notably, I do not know how to make the current behaviour (including untracked files) the default option
- when this option is activated, it becomes impossible to add a new file to the repo ; a special UI element should be added to address this.