### PR TITLE
Preventing multiple opening of the same repo

### DIFF
--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -579,7 +579,12 @@ SideBar::SideBar(TabWidget *tabs, QWidget *parent)
       tabs->setCurrentIndex(index.row());
   });
 
-  connect(view, &QTreeView::doubleClicked, [this](const QModelIndex &index) {
+  connect(view, &QTreeView::doubleClicked, [tabs, this](const QModelIndex &index) {
+    QModelIndex parent = index.parent();
+    if (parent.isValid() && parent.row() == RepoModel::Repo) {
+      tabs->setCurrentIndex(index.row());
+      return;
+    }
     // Open existing path.
     QString path = index.data(PathRole).toString();
     if (!path.isEmpty()) {

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -588,6 +588,13 @@ SideBar::SideBar(TabWidget *tabs, QWidget *parent)
     // Open existing path.
     QString path = index.data(PathRole).toString();
     if (!path.isEmpty()) {
+      for (int i = 0; i < tabs->count(); i++) {
+          RepoView *view = static_cast<RepoView *>(tabs->widget(i));
+          if (path == view->repo().workdir().path()) {
+            tabs->setCurrentIndex(i);
+            return;
+          }
+      }
       MainWindow::open(path);
       return;
     }


### PR DESCRIPTION
When one double-clicks on a currently opened repo in the Open or Recent sections of the sidebar, this repo gets opened another time in a new tab.

This checks for already opened repo on double-click to switch to the existing tab instead.