### PR TITLE
Add menu options and hotkeys for staging and unstaging

### DIFF
--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -157,6 +157,14 @@ void Diff::sort(SortRole role, Qt::SortOrder order)
   });
 }
 
+void Diff::setAllStaged(bool staged, bool yieldFocus)
+{
+  QStringList paths;
+  for (int i = 0; i < count(); ++i)
+    paths.append(name(i));
+  index().setStaged(paths, staged);
+}
+
 char Diff::statusChar(git_delta_t status)
 {
   if (status == GIT_DELTA_CONFLICTED)

--- a/src/git/Diff.h
+++ b/src/git/Diff.h
@@ -76,6 +76,8 @@ public:
 
   void sort(SortRole role, Qt::SortOrder order = Qt::AscendingOrder);
 
+  void setAllStaged(bool staged, bool yieldFocus = true);
+
   static char statusChar(git_delta_t status);
 
 private:

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -500,18 +500,12 @@ public:
     mStage = new QPushButton(tr("Stage All"), this);
     mStage->setObjectName("StageAll");
     connect(mStage, &QPushButton::clicked, [this] {
-      QStringList paths;
-      for (int i = 0; i < mDiff.count(); ++i)
-        paths.append(mDiff.name(i));
-      mDiff.index().setStaged(paths, true);
+      stage();
     });
 
     mUnstage = new QPushButton(tr("Unstage All"), this);
     connect(mUnstage, &QPushButton::clicked, [this] {
-      QStringList paths;
-      for (int i = 0; i < mDiff.count(); ++i)
-        paths.append(mDiff.name(i));
-      mDiff.index().setStaged(paths, false);
+      unstage();
     });
 
     mCommit = new QPushButton(tr("Commit"), this);
@@ -552,6 +546,26 @@ public:
   bool isCommitEnabled() const
   {
     return mCommit->isEnabled();
+  }
+
+  void stage()
+  {
+    mDiff.setAllStaged(true);
+  }
+
+  bool isStageEnabled() const
+  {
+    return mStage->isEnabled();
+  }
+
+  void unstage()
+  {
+    mDiff.setAllStaged(false);
+  }
+
+  bool isUnstageEnabled() const
+  {
+    return mUnstage->isEnabled();
   }
 
   void setMessage(const QString &message)
@@ -739,6 +753,32 @@ bool DetailView::isCommitEnabled() const
           static_cast<CommitEditor *>(widget)->isCommitEnabled());
 }
 
+void DetailView::stage()
+{
+  Q_ASSERT(isStageEnabled());
+  static_cast<CommitEditor *>(mDetail->currentWidget())->stage();
+}
+
+bool DetailView::isStageEnabled() const
+{
+  QWidget *widget = mDetail->currentWidget();
+  return (mDetail->currentIndex() == EditorIndex &&
+          static_cast<CommitEditor *>(widget)->isStageEnabled());
+}
+
+void DetailView::unstage()
+{
+  Q_ASSERT(isUnstageEnabled());
+  static_cast<CommitEditor *>(mDetail->currentWidget())->unstage();
+}
+
+bool DetailView::isUnstageEnabled() const
+{
+  QWidget *widget = mDetail->currentWidget();
+  return (mDetail->currentIndex() == EditorIndex &&
+          static_cast<CommitEditor *>(widget)->isUnstageEnabled());
+}
+
 RepoView::ViewMode DetailView::viewMode() const
 {
   return static_cast<RepoView::ViewMode>(mContent->currentIndex());
@@ -784,6 +824,9 @@ void DetailView::setDiff(
 
   ContentWidget *cw = static_cast<ContentWidget *>(mContent->currentWidget());
   cw->setDiff(diff, file, pathspec);
+
+  // Update menu actions.
+  MenuBar::instance(this)->updateRepository();
 }
 
 void DetailView::cancelBackgroundTasks()

--- a/src/ui/DetailView.h
+++ b/src/ui/DetailView.h
@@ -54,6 +54,12 @@ public:
   void commit();
   bool isCommitEnabled() const;
 
+  // stage / unstage
+  void stage();
+  bool isStageEnabled() const;
+  void unstage();
+  bool isUnstageEnabled() const;
+
   // mode
   RepoView::ViewMode viewMode() const;
   void setViewMode(RepoView::ViewMode mode, bool spontaneous);

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -339,6 +339,20 @@ MenuBar::MenuBar(QWidget *parent)
 
   repository->addSeparator();
 
+  mStageAll = repository->addAction(tr("Stage All"));
+  mStageAll->setShortcut(tr("Ctrl++"));
+  connect(mStageAll, &QAction::triggered, [this] {
+    view()->stage();
+  });
+
+  mUnstageAll = repository->addAction(tr("Unstage All"));
+  mUnstageAll->setShortcut(tr("Ctrl+-"));
+  connect(mUnstageAll, &QAction::triggered, [this] {
+    view()->unstage();
+  });
+
+  repository->addSeparator();
+
   mCommit = repository->addAction(tr("Commit"));
   mCommit->setShortcut(tr("Ctrl+Shift+C"));
   connect(mCommit, &QAction::triggered, [this] {
@@ -817,6 +831,8 @@ void MenuBar::updateRepository()
   RepoView *view = win ? win->currentView() : nullptr;
   mConfigureRepository->setEnabled(view);
   mCommit->setEnabled(view && view->isCommitEnabled());
+  mStageAll->setEnabled(view && view->isStageEnabled());
+  mUnstageAll->setEnabled(view && view->isUnstageEnabled());
   mAmendCommit->setEnabled(view);
 
   bool lfs = view && view->repo().lfsIsInitialized();

--- a/src/ui/MenuBar.h
+++ b/src/ui/MenuBar.h
@@ -69,6 +69,8 @@ private:
 
   // Repository
   QAction *mConfigureRepository;
+  QAction *mStageAll;
+  QAction *mUnstageAll;
   QAction *mCommit;
   QAction *mAmendCommit;
   QAction *mLfsUnlock;

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -490,6 +490,26 @@ bool RepoView::isCommitEnabled() const
   return mDetails->isCommitEnabled();
 }
 
+void RepoView::stage()
+{
+  mDetails->stage();
+}
+
+bool RepoView::isStageEnabled() const
+{
+  return mDetails->isStageEnabled();
+}
+
+void RepoView::unstage()
+{
+  mDetails->unstage();
+}
+
+bool RepoView::isUnstageEnabled() const
+{
+  return mDetails->isUnstageEnabled();
+}
+
 RepoView::ViewMode RepoView::viewMode() const
 {
   return mDetails->viewMode();

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -93,6 +93,12 @@ public:
   void commit();
   bool isCommitEnabled() const;
 
+  // stage / unstage
+  void stage();
+  bool isStageEnabled() const;
+  void unstage();
+  bool isUnstageEnabled() const;
+
   // mode
   ViewMode viewMode() const;
   void setViewMode(ViewMode mode);


### PR DESCRIPTION
Implements #227
Fix menu "Repository" not being updated on switching diffs / commits (resulted in menu action "Commit" being available when viewing a commit diff)