### PR TITLE
Preventing double-opening of submodule in tabs

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -192,6 +192,15 @@ RepoView *MainWindow::addTab(const QString &path)
   if (path.isEmpty())
     return nullptr;
 
+  TabWidget *tabs = tabWidget();
+  for (int i = 0; i < tabs->count(); i++) {
+        RepoView *view = static_cast<RepoView *>(tabs->widget(i));
+        if (path == view->repo().workdir().path()) {
+          tabs->setCurrentIndex(i);
+          return view;
+        }
+  }
+
   git::Repository repo = git::Repository::open(path, true);
   if (!repo.isValid()) {
     warnInvalidRepo(path);
@@ -207,6 +216,15 @@ RepoView *MainWindow::addTab(const git::Repository &repo)
   QDir dir = repo.workdir();
   RecentRepositories::instance()->add(dir.path());
 
+  TabWidget *tabs = tabWidget();
+  for (int i = 0; i < tabs->count(); i++) {
+        RepoView *view = static_cast<RepoView *>(tabs->widget(i));
+        if (dir.path() == view->repo().workdir().path()) {
+          tabs->setCurrentIndex(i);
+          return view;
+        }
+  }
+
   RepoView *view = new RepoView(repo, this);
   git::RepositoryNotifier *notifier = repo.notifier();
   connect(notifier, &git::RepositoryNotifier::referenceUpdated,
@@ -215,7 +233,6 @@ RepoView *MainWindow::addTab(const git::Repository &repo)
     updateWindowTitle();
   });
 
-  TabWidget *tabs = tabWidget();
   emit tabs->tabAboutToBeInserted();
   tabs->setCurrentIndex(tabs->addTab(view, dir.dirName()));
 


### PR DESCRIPTION
I did not catch this situation when fixing the sidebar : submodules can be opened multiple times in multiple tabs.
This commit does not change the current behaviour when the Open submodules in tabs option is not checked.