### PR TITLE
Allow more than 99 columns in line length plugin

### DIFF
--- a/src/dialogs/PluginsPanel.cpp
+++ b/src/dialogs/PluginsPanel.cpp
@@ -94,6 +94,7 @@ void PluginsPanel::refresh()
 
           case Plugin::Integer: {
             QSpinBox *spinBox = new QSpinBox(&dialog);
+            spinBox->setMaximum(999);
             spinBox->setValue(value.toInt());
             auto signal = QOverload<int>::of(&QSpinBox::valueChanged);
             connect(spinBox, signal, [plugin, key](int value) {


### PR DESCRIPTION
With a workaround to bug #219, I could test it.