### PR TITLE
Makes the commit message uses plain text.

### DIFF
--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -34,7 +34,7 @@
 #include <QRegularExpression>
 #include <QStackedWidget>
 #include <QStyle>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QToolButton>
 #include <QUrl>
 #include <QVBoxLayout>
@@ -62,11 +62,11 @@ QString brightText(const QString &text)
   return kAltFmt.arg(QPalette().color(QPalette::BrightText).name(), text);
 }
 
-class MessageLabel : public QTextEdit
+class MessageLabel : public QPlainTextEdit
 {
 public:
   MessageLabel(QWidget *parent = nullptr)
-    : QTextEdit(parent)
+    : QPlainTextEdit(parent)
   {
     setObjectName("MessageLabel");
     setFrameShape(QFrame::NoFrame);
@@ -83,14 +83,14 @@ public:
 protected:
   QSize minimumSizeHint() const override
   {
-    QSize size = QTextEdit::minimumSizeHint();
+    QSize size = QPlainTextEdit::minimumSizeHint();
     return QSize(size.width(), fontMetrics().lineSpacing());
   }
 
   QSize viewportSizeHint() const override
   {
     // Choose the smaller of the height of the document or five lines.
-    QSize size = QTextEdit::viewportSizeHint();
+    QSize size = QPlainTextEdit::viewportSizeHint();
     int height = document()->documentLayout()->documentSize().height();
     return QSize(size.width(), qMin(height, 5 * fontMetrics().lineSpacing()));
   }
@@ -248,7 +248,7 @@ public:
     mSeparator->setFrameShape(QFrame::HLine);
 
     mMessage = new MessageLabel(this);
-    connect(mMessage, &QTextEdit::copyAvailable,
+    connect(mMessage, &QPlainTextEdit::copyAvailable,
             MenuBar::instance(this), &MenuBar::updateCutCopyPaste);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
@@ -445,7 +445,7 @@ private:
   QLabel *mParents;
   QLabel *mPicture;
   QFrame *mSeparator;
-  QTextEdit *mMessage;
+  QPlainTextEdit *mMessage;
   AuthorDate *mAuthorDate;
 
   QString mId;
@@ -470,10 +470,10 @@ public:
     labelLayout->addStretch();
     labelLayout->addWidget(mStatus);
 
-    mMessage = new QTextEdit(this);
+    mMessage = new QPlainTextEdit(this);
     mMessage->setObjectName("MessageEditor");
     mMessage->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-    connect(mMessage, &QTextEdit::textChanged, [this] {
+    connect(mMessage, &QPlainTextEdit::textChanged, [this] {
       mPopulate = false;
 
       bool empty = mMessage->toPlainText().isEmpty();
@@ -486,11 +486,11 @@ public:
 
     // Update menu items.
     MenuBar *menuBar = MenuBar::instance(this);
-    connect(mMessage, &QTextEdit::undoAvailable,
+    connect(mMessage, &QPlainTextEdit::undoAvailable,
             menuBar, &MenuBar::updateUndoRedo);
-    connect(mMessage, &QTextEdit::redoAvailable,
+    connect(mMessage, &QPlainTextEdit::redoAvailable,
             menuBar, &MenuBar::updateUndoRedo);
-    connect(mMessage, &QTextEdit::copyAvailable,
+    connect(mMessage, &QPlainTextEdit::copyAvailable,
             menuBar, &MenuBar::updateCutCopyPaste);
 
     QVBoxLayout *messageLayout = new QVBoxLayout;
@@ -697,7 +697,7 @@ private:
   git::Diff mDiff;
 
   QLabel *mStatus;
-  QTextEdit *mMessage;
+  QPlainTextEdit *mMessage;
   QPushButton *mStage;
   QPushButton *mUnstage;
   QPushButton *mCommit;


### PR DESCRIPTION
This fix the unnecessary rich text on paste in commit message input.

Actual release:
![Screen Shot 2019-10-03 at 8 56 56 PM](https://user-images.githubusercontent.com/1365683/66171981-91256600-e620-11e9-8ca2-42a1f8fb9800.png)



With this changes:
![Screen Shot 2019-10-03 at 9 00 22 PM](https://user-images.githubusercontent.com/1365683/66172051-e2cdf080-e620-11e9-8f6a-736ed54e2d1c.png)
