### PR TITLE
Sets settings dialog window type to dialog

### DIFF
--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -665,6 +665,7 @@ private:
 SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   : QMainWindow(parent)
 {
+  setWindowFlag(Qt::Dialog);
   setMinimumWidth(500);
   setAttribute(Qt::WA_DeleteOnClose);
   setUnifiedTitleAndToolBarOnMac(true);


### PR DESCRIPTION
Fixes settings window being treated differently than repository config dialog by window managers.