### PR TITLE
Fixed the bug that causes duplicate revert message.

### DIFF
--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -579,7 +579,7 @@ public:
 
     // Pre-populate commit editor with the merge message.
     QString msg = RepoView::parentView(this)->repo().message();
-    if (!msg.isEmpty())
+    if (!msg.isEmpty() && !msg.toLower().contains("revert"))
       mMessage->setPlainText(msg);
   }
 


### PR DESCRIPTION
Fixed the bug that caused the revert message to be coming back while making new changes.

To reproduce the bug, is simple:
Make a revert, so make any change. The commit message will take a previous revert message.