### PR TITLE
Fix the invalid commit message when occurs conflict on merge --squash

### DIFF
--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -592,6 +592,7 @@ Commit Repository::commit(
 
   // Cleanup merge state.
   switch (state()) {
+    case GIT_REPOSITORY_STATE_NONE:
     case GIT_REPOSITORY_STATE_MERGE:
     case GIT_REPOSITORY_STATE_REVERT:
     case GIT_REPOSITORY_STATE_CHERRYPICK:


### PR DESCRIPTION
This fix a similar issue of commit f445b2b7cb8e2809fe1f47207663826d7dbea71e when occurs conflict on uses merge --squash.

Issue: After occurs conflict with merge --squash and solve it, the next commits messages is replaced to previous conflict alerts.