### PR TITLE
Fixes quitting the application

### DIFF
--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -162,9 +162,7 @@ MenuBar::MenuBar(QWidget *parent)
   QAction *quit = file->addAction(tr("Exit"));
   quit->setMenuRole(QAction::QuitRole);
   quit->setShortcut(QKeySequence::Quit);
-  connect(quit, &QAction::triggered, [] {
-    QCoreApplication::postEvent(qApp, new QCloseEvent);
-  });
+  connect(quit, &QAction::triggered, &QApplication::closeAllWindows);
 #endif
 
   // Edit


### PR DESCRIPTION
With QT 5.14 it seems that posting a `QCloseEvent` to the main loop won't close all top level windows