### PR TITLE
Fixes crash on Fetch All menu option

### DIFF
--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -865,6 +865,7 @@ void MenuBar::updateRemote()
   RepoView *view = win ? win->currentView() : nullptr;
   mConfigureRemotes->setEnabled(view);
   mFetch->setEnabled(view);
+  mFetchAll->setEnabled(view);
   mPull->setEnabled(view && !view->repo().isBare());
   mPush->setEnabled(view);
   mFetchFrom->setEnabled(view);


### PR DESCRIPTION
Fixes issue that causes breaking program by clicking the Fetch All option when you do not have any open repository.

Issue: #382