### PR TITLE
Fix squash incorrect Log Entry.

### DIFF
--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -697,6 +697,11 @@ void RepoView::visitLink(const QString &link)
     return;
   }
 
+  if (action == "squash") {
+    merge(flags | Squash, ref);
+    return;
+  }
+
   if (action == "config") {
     if (query.queryItemValue("global") == "true") {
       SettingsDialog::openSharedInstance();
@@ -1199,6 +1204,8 @@ void RepoView::merge(
   } else if (flags & Rebase) {
     title = tr("Rebase");
     textFmt = tr("%2 on %1");
+  } else if (squashflag) {
+    title = tr("Squash");
   }
 
   QString headName = head.name();
@@ -1503,7 +1510,7 @@ void RepoView::squash(
       if (kind == GIT_ERROR_MERGE && msg.contains("overwritten by merge")) {
         QString text =
           tr("You may be able to rebase by <a href='action:stash'>stashing</a> "
-             "before trying to <a href='action:merge'>merge</a>. Then "
+             "before trying to <a href='action:squash'>squash</a>. Then "
              "<a href='action:unstash'>unstash</a> to restore your changes.");
         err->addEntry(LogEntry::Hint, text);
       }


### PR DESCRIPTION
**Currently**

![older 2](https://user-images.githubusercontent.com/1365683/81004911-7ec41280-8e23-11ea-92a1-1923e63d6980.JPG)
![older](https://user-images.githubusercontent.com/1365683/81004912-7f5ca900-8e23-11ea-9895-5d6d2668255e.JPG)

---

**After fix**

![fixed](https://user-images.githubusercontent.com/1365683/81004948-91d6e280-8e23-11ea-9dbf-09e831a5a3de.JPG)
![fixed 2](https://user-images.githubusercontent.com/1365683/81004946-913e4c00-8e23-11ea-9748-2b154e035f4d.JPG)
