### PR TITLE
Fix missing QPainterPath includes

### DIFF
--- a/src/ui/Badge.cpp
+++ b/src/ui/Badge.cpp
@@ -10,6 +10,7 @@
 #include "Badge.h"
 #include "app/Application.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QStyleOption>
 
 namespace {

--- a/src/ui/ColumnView.cpp
+++ b/src/ui/ColumnView.cpp
@@ -15,6 +15,7 @@
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QVBoxLayout>
 
 #ifdef Q_OS_WIN

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -31,6 +31,7 @@
 #include <QApplication>
 #include <QMenu>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPushButton>
 #include <QStyledItemDelegate>
 #include <QTextLayout>

--- a/src/ui/CommitToolBar.cpp
+++ b/src/ui/CommitToolBar.cpp
@@ -15,6 +15,7 @@
 #include <QApplication>
 #include <QMenu>
 #include <QPainter>
+#include <QPainterPath>
 #include <QProxyStyle>
 #include <QStyleOption>
 #include <QToolButton>

--- a/src/ui/ContextMenuButton.cpp
+++ b/src/ui/ContextMenuButton.cpp
@@ -9,6 +9,7 @@
 
 #include "ContextMenuButton.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QStyleOption>
 #include <QStylePainter>
 #include <QToolBar>

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -30,6 +30,7 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QStackedWidget>

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -45,6 +45,7 @@
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPushButton>
 #include <QSaveFile>
 #include <QScrollBar>

--- a/src/ui/ExpandButton.cpp
+++ b/src/ui/ExpandButton.cpp
@@ -9,6 +9,7 @@
 
 #include "ExpandButton.h"
 #include <QPainter>
+#include <QPainterPath>
 
 ExpandButton::ExpandButton(QWidget *parent)
   : QToolButton(parent)

--- a/src/ui/FileList.cpp
+++ b/src/ui/FileList.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QSettings>
 #include <QStyledItemDelegate>
 #include <QWindow>
@@ -215,7 +216,7 @@ FileList::FileList(const git::Repository &repo, QWidget *parent)
 {
   Theme *theme = Application::theme();
   setPalette(theme->fileList());
-  
+
   setAlternatingRowColors(true);
   setFrameShape(QFrame::NoFrame);
   setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -436,7 +437,7 @@ void FileList::updateMenu(const git::Diff &diff)
   QSet<git_delta_t> kinds;
   for (int i = 0; i < diff.count(); ++i)
     kinds.insert(diff.status(i));
-  foreach (git_delta_t kind, kinds) {    
+  foreach (git_delta_t kind, kinds) {
     QString name;
     switch (kind) {
       case GIT_DELTA_ADDED:      name = tr("Added");       break;
@@ -462,7 +463,7 @@ void FileList::updateMenu(const git::Diff &diff)
       }
 
       selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect);
-    }); 
+    });
   }
 
   // ignore whitespace

--- a/src/ui/FindWidget.cpp
+++ b/src/ui/FindWidget.cpp
@@ -15,6 +15,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPainter>
+#include <QPainterPath>
 #include <QShortcut>
 #include <QShowEvent>
 #include <QStyleOption>

--- a/src/ui/Footer.cpp
+++ b/src/ui/Footer.cpp
@@ -11,6 +11,7 @@
 #include <QHBoxLayout>
 #include <QMenu>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPaintEvent>
 #include <QPen>
 #include <QStyleOption>

--- a/src/ui/SearchField.cpp
+++ b/src/ui/SearchField.cpp
@@ -9,6 +9,7 @@
 
 #include "SearchField.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QStyle>
 #include <QToolButton>
 

--- a/src/ui/ToolBar.cpp
+++ b/src/ui/ToolBar.cpp
@@ -21,6 +21,7 @@
 #include <QHBoxLayout>
 #include <QMenu>
 #include <QPainter>
+#include <QPainterPath>
 #include <QStyleOptionToolButton>
 #include <QToolButton>
 #include <QWindow>


### PR DESCRIPTION
Newer versions of Qt no longer include QPainterPath through QPainter. This PR fixes build issues against new versions of Qt