### PR TITLE
Fix default palette application on Qt 5.15.0

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -27,6 +27,7 @@
 #include <QNetworkReply>
 #include <QOperatingSystemVersion>
 #include <QSettings>
+#include <QStyle>
 #include <QSysInfo>
 #include <QTimer>
 #include <QTranslator>
@@ -186,6 +187,9 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
 
   // Enable system proxy auto-detection.
   QNetworkProxyFactory::setUseSystemConfiguration(true);
+
+  // Set default pallete. Pre Qt 5.15.0 this should be the same as the default
+  QApplication::setPalette(QApplication::style()->standardPalette());
 
   // Do platform-specific initialization.
 #if defined(Q_OS_MAC)


### PR DESCRIPTION
Investigation at https://github.com/gitahead/gitahead/issues/443#issuecomment-643557057

The problem is that in Qt 5.15.0 the default style is no longer applied. The fix is to just apply the same style that they used to in the pre Qt 5.15.0 versions. I'm fairly certain this style hasn't changed, we just have to manually initialize it ourselves.

Took a guess at where this belonged, I stuck it near the end of the Application() constructor but I'm fairly unfamiliar with the code base so am not completely sure that's right.

Light theme
![image](https://user-images.githubusercontent.com/1069811/84558330-ebfe7980-ace6-11ea-9d00-90ee92072848.png)
Dark theme
![image](https://user-images.githubusercontent.com/1069811/84558335-f7ea3b80-ace6-11ea-8c26-6c1320446dc2.png)

*Note*
I only tested this on Qt version 5.15.0, I'm going off Qt source code inspection on 5.14.2 that this should behave the same across all Qt versions