### PR TITLE
Add GitAhead setting no-translation

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -158,7 +158,10 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
   setStyle(mTheme->style());
   setStyleSheet(mTheme->styleSheet());
 
-  if (!parser.isSet("no-translation")) {
+  // Read translation settings
+  QSettings settings;
+  if ((!settings.value("translation/disable", false).toBool()) &&
+      (!parser.isSet("no-translation"))) {
     // Load translation files.
     QLocale locale;
     QDir l10n = Settings::l10nDir();
@@ -227,7 +230,6 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
   });
 
   // Read tracking settings.
-  QSettings settings;
   settings.beginGroup("tracking");
   QByteArray tid(GITAHEAD_TRACKING_ID);
   if (!tid.isEmpty() && settings.value("enabled", true).toBool()) {

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -115,6 +115,7 @@ public:
     mPushCommit = new QCheckBox(tr("Push after each commit"), this);
     mPullUpdate = new QCheckBox(tr("Update submodules after pull"), this);
     mAutoPrune = new QCheckBox(tr("Prune when fetching"), this);
+    mNoTranslation = new QCheckBox(tr("No translation"), this);
 
     mStoreCredentials = new QCheckBox(
       tr("Store credentials in secure storage"), this);
@@ -133,6 +134,7 @@ public:
     form->addRow(QString(), mPushCommit);
     form->addRow(QString(), mPullUpdate);
     form->addRow(QString(), mAutoPrune);
+    form->addRow(tr("Language:"), mNoTranslation);
     form->addRow(tr("Credentials:"), mStoreCredentials);
     form->addRow(tr("Usage reporting:"), mUsageReporting);
     form->addRow(QString(), privacy);
@@ -177,6 +179,10 @@ public:
       Settings::instance()->setValue("global/autoprune/enable", checked);
     });
 
+    connect(mNoTranslation, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setValue("translation/disable", checked);
+    });
+
     connect(mStoreCredentials, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("credential/store", checked);
       delete CredentialHelper::instance();
@@ -205,6 +211,7 @@ public:
     mAutoPrune->setChecked(settings->value("autoprune/enable").toBool());
     settings->endGroup();
 
+    mNoTranslation->setChecked(settings->value("translation/disable").toBool());
     mStoreCredentials->setChecked(settings->value("credential/store").toBool());
     mUsageReporting->setChecked(settings->value("tracking/enabled").toBool());
   }
@@ -218,6 +225,7 @@ private:
   QCheckBox *mPushCommit;
   QCheckBox *mPullUpdate;
   QCheckBox *mAutoPrune;
+  QCheckBox *mNoTranslation;
   QCheckBox *mStoreCredentials;
   QCheckBox *mUsageReporting;
 };


### PR DESCRIPTION
In addition to parameter '--no-translation', but stored in GitAhead user settings file
(~/.config/gitahead.com/GitAhead.conf)
New setting checkbox: 'Language: No translation' with default = false

![No-translation](https://user-images.githubusercontent.com/67198194/85219571-51b4ca80-b3a5-11ea-90ea-df05586fe6c5.png)