### PR TITLE
Add repository alias

### DIFF
--- a/src/conf/CMakeLists.txt
+++ b/src/conf/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(conf
 )
 
 target_link_libraries(conf
+  index
   lua
   Qt5::Core
 )

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -36,6 +36,16 @@ RecentRepository *RecentRepositories::repository(int index) const
   return mRepos.at(index);
 }
 
+RecentRepository *RecentRepositories::repository(const QString &path) const
+{
+  for (int index = 0; index < mRepos.count(); index++) {
+    if (mRepos.at(index)->path().compare(path) == 0)
+      return mRepos.at(index);
+  }
+
+  return nullptr;
+}
+
 void RecentRepositories::clear()
 {
   emit repositoryAboutToBeRemoved();

--- a/src/conf/RecentRepositories.h
+++ b/src/conf/RecentRepositories.h
@@ -22,6 +22,7 @@ class RecentRepositories : public QObject
 public:
   int count() const;
   RecentRepository *repository(int index) const;
+  RecentRepository *repository(const QString &path) const;
 
   void clear();
   void remove(int index);

--- a/src/conf/RecentRepository.cpp
+++ b/src/conf/RecentRepository.cpp
@@ -8,10 +8,20 @@
 //
 
 #include "RecentRepository.h"
+#include "git/Repository.h"
+#include "git/Config.h"
 
 RecentRepository::RecentRepository(const QString &path, QObject *parent)
   : QObject(parent), mPath(path)
-{}
+{
+  git::Repository repo = git::Repository::open(mPath, false);
+  // Lookup [repository] alias =
+  if (repo.isValid()) {
+    mAlias = repo.config().value<QString>("repository.alias");
+  } else {
+    mAlias.clear();
+  }
+}
 
 QString RecentRepository::path() const
 {
@@ -20,10 +30,17 @@ QString RecentRepository::path() const
 
 QString RecentRepository::name() const
 {
+  if (!mAlias.isEmpty())
+    return mAlias;
+
   return mPath.section('/', -mSections);
 }
 
 void RecentRepository::increment()
 {
-  ++mSections;
+  if (mAlias.isEmpty()) {
+    ++mSections;
+  } else {
+    mAlias.clear();
+  }
 }

--- a/src/conf/RecentRepository.h
+++ b/src/conf/RecentRepository.h
@@ -26,6 +26,7 @@ private:
   void increment();
 
   QString mPath;
+  QString mAlias;
   int mSections = 1;
 
   friend class RecentRepositories;

--- a/src/dialogs/ConfigDialog.cpp
+++ b/src/dialogs/ConfigDialog.cpp
@@ -79,6 +79,7 @@ public:
   GeneralPanel(RepoView *view, QWidget *parent = nullptr)
     : QWidget(parent), mRepo(view->repo())
   {
+    mAlias = new QLineEdit(this);
     mName = new QLineEdit(this);
     mEmail = new QLineEdit(this);
 
@@ -98,6 +99,7 @@ public:
     mAutoPrune = new QCheckBox(tr("Prune when fetching"), this);
 
     QFormLayout *form = new QFormLayout(this);
+    form->addRow(tr("Repository alias:"), mAlias);
     form->addRow(tr("User name:"), mName);
     form->addRow(tr("User email:"), mEmail);
     form->addRow(tr("Automatic actions:"), fetchLayout);
@@ -108,6 +110,10 @@ public:
     init();
 
     // Connect signals after initializing fields.
+    connect(mAlias, &QLineEdit::textChanged, [this](const QString &text) {
+      mRepo.config().setValue("repository.alias", text);
+    });
+
     connect(mName, &QLineEdit::textChanged, [this](const QString &text) {
       mRepo.config().setValue("user.name", text);
     });
@@ -143,6 +149,7 @@ public:
   void init()
   {
     git::Config config = mRepo.config();
+    mAlias->setText(config.value<QString>("repository.alias"));
     mName->setText(config.value<QString>("user.name"));
     mEmail->setText(config.value<QString>("user.email"));
 
@@ -169,6 +176,7 @@ public:
 
 private:
   git::Repository mRepo;
+  QLineEdit *mAlias;
   QLineEdit *mName;
   QLineEdit *mEmail;
 

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -17,6 +17,7 @@
 #include "TabWidget.h"
 #include "ToolBar.h"
 #include "conf/RecentRepositories.h"
+#include "conf/RecentRepository.h"
 #include "conf/Settings.h"
 #include "git/Repository.h"
 #include "git/Submodule.h"
@@ -44,28 +45,6 @@ const QString kActiveKey = "active";
 const QString kSidebarKey = "sidebar";
 const QString kGeometryKey = "geometry";
 const QString kWindowsGroup = "windows";
-
-class TabName
-{
-public:
-  TabName(const QString &path)
-    : mPath(path)
-  {}
-
-  QString name() const
-  {
-    return mPath.section('/', -mSections);
-  }
-
-  void increment()
-  {
-    ++mSections;
-  }
-
-private:
-  QString mPath;
-  int mSections = 1;
-};
 
 } // anon. namespace
 
@@ -485,25 +464,11 @@ void MainWindow::warnInvalidRepo(const QString &path)
 
 void MainWindow::updateTabNames()
 {
-  QList<TabName> names;
-  for (int i = 0; i < count(); ++i) {
-    TabName name(view(i)->repo().workdir().path());
-    auto functor = [&name](const TabName &rhs) {
-      return (name.name() == rhs.name());
-    };
-
-    QList<TabName>::iterator it, end = names.end();
-    while ((it = std::find_if(names.begin(), end, functor)) != end) {
-      it->increment();
-      name.increment();
-    }
-
-    names.append(name);
-  }
-
   TabWidget *tabs = tabWidget();
-  for (int i = 0; i < count(); ++i)
-    tabs->setTabText(i, names.at(i).name());
+  for (int i = 0; i < count(); ++i) {
+    RecentRepository *repo = RecentRepositories::instance()->repository(view(i)->repo().workdir().path());
+    tabs->setTabText(i, repo->name());
+  }
 }
 
 void MainWindow::updateInterface()


### PR DESCRIPTION
Substitute repository name with repository alias.
A repository alias can be set by 'git config repository.alias "alias name"'
or with the Repository / Configure Repository... dialog

This might address issue #430 

Info: This is a simple stupid implementation. I removed the TabName class which had the same code as the RecentRepository class to get the alias on the SideBar an on the Tabs. The 'old' name is used as fallback in case two repositories have the same alias.

![Repository-alias](https://user-images.githubusercontent.com/67198194/85221091-60a17a00-b3b1-11ea-91e4-a4ea79abe467.png)

![Repository-tabs](https://user-images.githubusercontent.com/67198194/85221096-64cd9780-b3b1-11ea-9a58-1a76ad0ca93d.png)
