### PR TITLE
Add 'delete tag' and 'delete branch' to CommitList context menu

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1485,12 +1485,35 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event)
       menu.addSeparator();
 
       menu.addAction(tr("Add Tag..."), [view, commit] {
-        view->promptToTag(commit);
+        view->promptToAddTag(commit);
       });
 
       menu.addAction(tr("New Branch..."), [view, commit] {
         view->promptToCreateBranch(commit);
       });
+
+      bool separator = true;
+      foreach (const git::Reference &ref, commit.refs()) {
+        if (ref.isTag()) {
+          if (separator) {
+            menu.addSeparator();
+            separator = false;
+          }
+          menu.addAction(tr("Delete tag %1").arg(ref.name()), [view, ref] {
+            view->promptToDeleteTag(ref);
+          });
+        }
+        if (ref.isLocalBranch() &&
+           (view->repo().head().name() != ref.name())) {
+          if (separator) {
+            menu.addSeparator();
+            separator = false;
+          }
+          menu.addAction(tr("Delete branch %1").arg(ref.name()), [view, ref] {
+            view->promptToDeleteBranch(ref);
+          });
+        }
+      }
 
       menu.addSeparator();
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -25,6 +25,8 @@
 #include "conf/Settings.h"
 #include "dialogs/CheckoutDialog.h"
 #include "dialogs/CommitDialog.h"
+#include "dialogs/DeleteBranchDialog.h"
+#include "dialogs/DeleteTagDialog.h"
 #include "dialogs/NewBranchDialog.h"
 #include "dialogs/RemoteDialog.h"
 #include "dialogs/SettingsDialog.h"
@@ -2054,6 +2056,13 @@ git::Branch RepoView::createBranch(
   return branch;
 }
 
+void RepoView::promptToDeleteBranch(const git::Reference &ref)
+{
+  DeleteBranchDialog *dialog = new DeleteBranchDialog(ref, this);
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->open();
+}
+
 void RepoView::promptToStash()
 {
   // Prompt to edit stash commit message.
@@ -2133,7 +2142,7 @@ void RepoView::popStash(int index)
   refresh();
 }
 
-void RepoView::promptToTag(const git::Commit &commit)
+void RepoView::promptToAddTag(const git::Commit &commit)
 {
   TagDialog *dialog = new TagDialog(mRepo, commit.shortId(),
     mRepo.defaultRemote(), this);
@@ -2155,6 +2164,13 @@ void RepoView::promptToTag(const git::Commit &commit)
       push(remote, tag);
   });
 
+  dialog->open();
+}
+
+void RepoView::promptToDeleteTag(const git::Reference &ref)
+{
+  DeleteTagDialog *dialog = new DeleteTagDialog(ref, this);
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->open();
 }
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -252,6 +252,7 @@ public:
     const git::Branch &upstream = git::Branch(),
     bool checkout = false,
     bool force = false);
+  void promptToDeleteBranch(const git::Reference &ref);
 
   // stash
   void promptToStash();
@@ -261,7 +262,8 @@ public:
   void popStash(int index = 0);
 
   // tag
-  void promptToTag(const git::Commit &commit);
+  void promptToAddTag(const git::Commit &commit);
+  void promptToDeleteTag(const git::Reference &ref);
 
   // reset
   void promptToReset(


### PR DESCRIPTION
All tags which can be deleted at the selected commit are added to the context menu.
The same applies for branches (local branches only, not checked out)

![Delete-tag](https://user-images.githubusercontent.com/67198194/85951330-c61dd980-b962-11ea-9d05-dd09809c859f.png)

![Delete-branch](https://user-images.githubusercontent.com/67198194/85951333-c9b16080-b962-11ea-9cd5-36d60cbc61e9.png)
