### PR TITLE
Add filemode changes to DiffView

### DIFF
--- a/src/git/Diff.h
+++ b/src/git/Diff.h
@@ -60,6 +60,9 @@ public:
   bool isStatusDiff() const;
   Index index() const { return d->index; }
 
+  uint16_t old_mode(int index) const { return d->delta(index)->old_file.mode; }
+  uint16_t new_mode(int index) const { return d->delta(index)->new_file.mode; }
+
   int count() const;
   Patch patch(int index) const;
   QString name(int index) const;

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -756,7 +756,7 @@ public:
       });
 
       // Show file mode diff
-      if (filemode || header.isEmpty()) {
+      if (filemode) {
         mOldMode = diff.old_mode(index);
         mNewMode = diff.new_mode(index);
 
@@ -766,12 +766,10 @@ public:
           mLabel->setText(kHunkFmt.arg(escaped));
 
           // Hide buttons
-          if (filemode) {
-            edit->setVisible(false);
-            if (discard)
-              discard->setVisible(false);
-            mButton->setVisible(false);
-          }
+          edit->setVisible(false);
+          if (discard)
+            discard->setVisible(false);
+          mButton->setVisible(false);
         }
       }
     }


### PR DESCRIPTION
Filemode changes are displayed as top hunk without checkbox and without toolbuttons. This should be a helpful information when copying repositorys betwen LinuxFS and WindowsFS. 
Unstaged new files (no patch info available) display the filemode 0 -> ... / modified files display the patch info @@ ... @@ ...

![DiffView](https://user-images.githubusercontent.com/67198194/85951863-2febb280-b966-11ea-8e17-e0732bc87124.png)
