### PR TITLE
Add browse for 'Local Directory' to CloneDialog

### DIFF
--- a/src/dialogs/CloneDialog.cpp
+++ b/src/dialogs/CloneDialog.cpp
@@ -60,31 +60,18 @@ public:
       });
     }
 
-    mUrl = new QLineEdit(this);
+    QFrame *url = new QFrame(this);
+    mUrl = new QLineEdit(url);
     mUrl->setMinimumWidth(mUrl->sizeHint().width() * 2);
     connect(mUrl, &QLineEdit::textChanged,
             this, &RemotePage::completeChanged);
 
+    QPushButton *browse = nullptr;
     if (repo) {
       mUrl->setReadOnly(true);
       mUrl->setText(repo->url(Repository::Https));
-    }
-
-    QLabel *label = nullptr;
-    QPushButton *browse = nullptr;
-    if (!repo) {
-      label = new QLabel(
-        tr("Examples of valid URLs include:<table cellspacing='8'>"
-           "<tr><td align='right'><b>HTTPS</b></td>"
-           "<td>https://hostname/path/to/repo.git</td></tr>"
-           "<tr><td align='right'><b>SSH</b></td>"
-           "<td>git@hostname:path/to/repo.git</td></tr>"
-           "<tr><td align='right'><b>Git</b></td>"
-           "<td>git://hostname/path/to/repo.git</td></tr>"
-           "<tr><td align='right'><b>Local</b></td>"
-           "<td>/path/to/repo, C:\\path\\to\\repo</td></tr></table>"), this);
-
-      browse = new QPushButton(tr("Local Directory"), mUrl);
+    } else {
+      browse = new QPushButton(tr("..."), url);
       connect(browse, &QPushButton::clicked, [this]() {
         QString title = tr("Choose Directory");
         QFileDialog *dialog = new QFileDialog(this, title, mUrl->text(), QString());
@@ -99,14 +86,32 @@ public:
       });
     }
 
+    QHBoxLayout *urlLayout = new QHBoxLayout(url);
+    urlLayout->setContentsMargins(0,0,0,0);
+    urlLayout->addWidget(mUrl);
+    if (browse)
+      urlLayout->addWidget(browse);
+
+    QLabel *label = nullptr;
+    if (!repo) {
+      label = new QLabel(
+        tr("Examples of valid URLs include:<table cellspacing='8'>"
+           "<tr><td align='right'><b>HTTPS</b></td>"
+           "<td>https://hostname/path/to/repo.git</td></tr>"
+           "<tr><td align='right'><b>SSH</b></td>"
+           "<td>git@hostname:path/to/repo.git</td></tr>"
+           "<tr><td align='right'><b>Git</b></td>"
+           "<td>git://hostname/path/to/repo.git</td></tr>"
+           "<tr><td align='right'><b>Local</b></td>"
+           "<td>/path/to/repo, C:\\path\\to\\repo</td></tr></table>"), this);
+    }
+
     QFormLayout *form = new QFormLayout(this);
     if (mProtocol)
       form->addRow(tr("Protocol:"), mProtocol);
-    form->addRow(tr("URL:"), mUrl);
+    form->addRow(tr("URL:"), url);
     if (label)
       form->addRow(label);
-    if (browse)
-      form->addRow(browse);
 
     // Register field.
     registerField("url", mUrl);

--- a/src/dialogs/CloneDialog.cpp
+++ b/src/dialogs/CloneDialog.cpp
@@ -43,7 +43,8 @@ public:
     setTitle(tr("Remote Repository URL"));
     setSubTitle(repo ?
       tr("Choose protocol to authenticate with the remote.") :
-      tr("Enter the URL of the remote repository."));
+      tr("Enter the URL of the remote repository or browse for a local "
+         "directory"));
 
     if (repo) {
       mProtocol = new QComboBox(this);
@@ -70,6 +71,7 @@ public:
     }
 
     QLabel *label = nullptr;
+    QPushButton *browse = nullptr;
     if (!repo) {
       label = new QLabel(
         tr("Examples of valid URLs include:<table cellspacing='8'>"
@@ -81,6 +83,20 @@ public:
            "<td>git://hostname/path/to/repo.git</td></tr>"
            "<tr><td align='right'><b>Local</b></td>"
            "<td>/path/to/repo, C:\\path\\to\\repo</td></tr></table>"), this);
+
+      browse = new QPushButton(tr("Local Directory"), mUrl);
+      connect(browse, &QPushButton::clicked, [this]() {
+        QString title = tr("Choose Directory");
+        QFileDialog *dialog = new QFileDialog(this, title, mUrl->text(), QString());
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->setFileMode(QFileDialog::Directory);
+        dialog->setOption(QFileDialog::ShowDirsOnly);
+        connect(dialog, &QFileDialog::fileSelected, [this](const QString &file) {
+          mUrl->setText(file);
+        });
+
+        dialog->open();
+      });
     }
 
     QFormLayout *form = new QFormLayout(this);
@@ -89,6 +105,8 @@ public:
     form->addRow(tr("URL:"), mUrl);
     if (label)
       form->addRow(label);
+    if (browse)
+      form->addRow(browse);
 
     // Register field.
     registerField("url", mUrl);


### PR DESCRIPTION
A QPushButton 'Local Directory' is added to the first page of the CloneDialog.
When cloning a repository a directory chooser dialog can be used instead of typing the repository url.

![local directory clone](https://user-images.githubusercontent.com/67198194/86906324-ad0bea00-c113-11ea-9316-05142cedb33b.png)

