### PR TITLE
Add horizontal scrollbar height to TextEditor viewportSizeHint()

### DIFF
--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -14,6 +14,7 @@
 #include <QMainWindow>
 #include <QStyle>
 #include <QWindow>
+#include <QScrollBar>
 
 using namespace Scintilla;
 
@@ -362,6 +363,11 @@ QSize TextEditor::viewportSizeHint() const
   int lines = annotationLines(line) + 1;
   int height = const_cast<TextEditor *>(this)->textHeight(line);
   int y = const_cast<TextEditor *>(this)->pointFromPosition(length()).y();
+
+  // Add extra height for scrollbar.
+  if (horizontalScrollBarVisible)
+    y += horizontalScrollBar()->height();
+
   return QSize(size.width(), y + (lines * height));
 }
 

--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -364,9 +364,10 @@ QSize TextEditor::viewportSizeHint() const
   int height = const_cast<TextEditor *>(this)->textHeight(line);
   int y = const_cast<TextEditor *>(this)->pointFromPosition(length()).y();
 
-  // Add extra height for scrollbar.
-  if (horizontalScrollBarVisible)
-    y += horizontalScrollBar()->height();
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
+  // FIXME: add height for horizontal scroll bar.
+  y += horizontalScrollBar()->height();
+#endif
 
   return QSize(size.width(), y + (lines * height));
 }


### PR DESCRIPTION
Solves issue #470 where the scrollbar hides the last line in DiffView.