### PR TITLE
Issue/476 Video Tutorial Links

### DIFF
--- a/src/dialogs/StartDialog.cpp
+++ b/src/dialogs/StartDialog.cpp
@@ -613,7 +613,7 @@ StartDialog::StartDialog(QWidget *parent)
   QString text = tr("View Getting Started Video");
   QPushButton *help = mButtonBox->addButton(text, QDialogButtonBox::ResetRole);
   connect(help, &QPushButton::clicked, [] {
-    QDesktopServices::openUrl(QUrl("https://gitahead.com/#tutorials"));
+    QDesktopServices::openUrl(QUrl("https://www.youtube.com/playlist?list=PLkhgTa3ULplz_DgalwtORMviEJeHy07EB"));
   });
 
   QVBoxLayout *layout = new QVBoxLayout(this);

--- a/src/ui/TabWidget.cpp
+++ b/src/ui/TabWidget.cpp
@@ -27,7 +27,7 @@ namespace {
 
 const QString kLinkFmt = "<a href='%1'>%2</a>";
 const QString kSupportLink = "mailto:support@gitahead.com";
-const QString kVideoLink = "https://gitahead.com/#tutorials";
+const QString kVideoLink = "https://www.youtube.com/playlist?list=PLkhgTa3ULplz_DgalwtORMviEJeHy07EB";
 
 class DefaultWidget : public QFrame
 {


### PR DESCRIPTION
Fixes issue #476 

Proposed Changes:

- Change the following links for `View getting started videos` from https://gitahead.com/#tutorials to the YouTube GitAhead tutorial [playlist](https://www.youtube.com/playlist?list=PLkhgTa3ULplz_DgalwtORMviEJeHy07EB)
          1. Start Dialog Box
          2. Tab Widget

Alternately, you could add a link to the YouTube playlist from https://gitahead.com/#tutorials and keep the links pointing there.