### PR TITLE
Add reduced mode to CommitList

### DIFF
--- a/src/ui/CommitToolBar.cpp
+++ b/src/ui/CommitToolBar.cpp
@@ -27,6 +27,7 @@ const QString kSortKey = "commit.sort.date";
 const QString kGraphKey = "commit.graph.visible";
 const QString kStatusKey = "commit.status.clean";
 const QString kCompactKey = "commit/compact";
+const QString kReducedKey = "commit/reduced";
 const QString kStyleSheet =
   "QToolBar {"
   "  border: none"
@@ -180,10 +181,27 @@ CommitToolBar::CommitToolBar(QWidget *parent)
   menu->addSeparator();
 
   QAction *compact = menu->addAction(tr("Compact Mode"));
+  QAction *reduced = menu->addAction(tr("Reduced Mode"));
+
   compact->setCheckable(true);
   compact->setChecked(Settings::instance()->value(kCompactKey).toBool());
-  connect(compact, &QAction::triggered, [this](bool checked) {
+  connect(compact, &QAction::triggered, [this, reduced](bool checked) {
+    if (checked) {
+      reduced->setChecked(false);
+      Settings::instance()->setValue(kReducedKey, false);
+    }
     Settings::instance()->setValue(kCompactKey, checked);
+    emit settingsChanged();
+  });
+
+  reduced->setCheckable(true);
+  reduced->setChecked(Settings::instance()->value(kReducedKey).toBool());
+  connect(reduced, &QAction::triggered, [this, compact](bool checked) {
+    if (checked) {
+      compact->setChecked(false);
+      Settings::instance()->setValue(kCompactKey, false);
+    }
+    Settings::instance()->setValue(kReducedKey, checked);
     emit settingsChanged();
   });
 }


### PR DESCRIPTION
Reduced mode is the middle between default and compact mode: 2 lines are used for the commitlist.
1st line: badges, date and id
2nd line: commit subject and author
When no badge is shown, the commit subject is vertically centered to align with the graphs circle.

![reduced_mode](https://user-images.githubusercontent.com/67198194/93329895-32033600-f81e-11ea-8465-0e2b8b968ffc.png)
