### PR TITLE
Add more badge colors for customization

### DIFF
--- a/conf/themes/Dark.lua
+++ b/conf/themes/Dark.lua
@@ -74,7 +74,7 @@ theme['files']     = {
 }
 
 -- status badge colors
--- { normal, selected, conflicted, head, notification }
+-- { normal, selected, conflicted, untracked, added, modified, renamed, deleted, head, localbranch, remotebranch, tag, notification }
 theme['badge']     = {
   foreground       = {
     normal         = '#E1E5F2',
@@ -83,9 +83,17 @@ theme['badge']     = {
   background       = {
     normal         = '#2A82DA', -- the default color
     selected       = '#E1E5F2', -- the color when a list item is selected
-    conflicted     = '#DA2ADA', -- the color of conflicted items
-    head           = '#52A500', -- a bolder color to indicate the HEAD
-    notification   = '#8C2026'  -- the color of toolbar notifications badges
+    conflicted     = '#DA2ADA', -- the color of conflicted items '!'
+    -- untracked      = '#2A82DA', -- the color of untracked items '?'
+    -- added          = '#296812', -- the color of added items 'A'
+    -- modified       = '#DA822A', -- the color of modified items 'M'
+    -- renamed        = '#822ADA', -- the color of renamed items 'R'
+    -- deleted        = '#781B20', -- the color of deleted items 'D'
+    head           = '#52A500', -- the color to indicate the HEAD
+    -- localbranch    = '#2A82DA', -- the color of local branch badges
+    -- remotebranch   = '#555B65', -- the color of remote branch badges 
+    -- tag            = '#DA822A', -- the color of tag badges
+    notification   = '#8C2026', -- the color of toolbar notifications badges
   }
 }
 

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -347,8 +347,40 @@ QColor CustomTheme::badge(BadgeRole role, BadgeState state)
       stateKey = "conflicted";
       break;
 
+    case BadgeState::Untracked:
+      stateKey = "untracked";
+      break;
+
+    case BadgeState::Added:
+      stateKey = "added";
+      break;
+
+    case BadgeState::Modified:
+      stateKey = "modified";
+      break;
+
+    case BadgeState::Renamed:
+      stateKey = "renamed";
+      break;
+
+    case BadgeState::Deleted:
+      stateKey = "deleted";
+      break;
+
     case BadgeState::Head:
       stateKey = "head";
+      break;
+
+    case BadgeState::Local:
+      stateKey = "localbranch";
+      break;
+
+    case BadgeState::Remote:
+      stateKey = "remotebranch";
+      break;
+
+    case BadgeState::Tag:
+      stateKey = "tag";
       break;
 
     case BadgeState::Notification:

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -433,6 +433,14 @@ QColor Theme::badge(BadgeRole role, BadgeState state)
       case BadgeRole::Background:
         switch (state) {
           case BadgeState::Normal:
+          case BadgeState::Untracked:
+          case BadgeState::Added:
+          case BadgeState::Modified:
+          case BadgeState::Renamed:
+          case BadgeState::Deleted:
+          case BadgeState::Local:
+          case BadgeState::Remote:
+          case BadgeState::Tag:
             return "#2A82DA";
 
           case BadgeState::Selected:
@@ -445,7 +453,7 @@ QColor Theme::badge(BadgeRole role, BadgeState state)
             return "#52A500";
 
           case BadgeState::Notification:
-            return "#D00000";
+            return "#8C2026";
         }
     }
   }
@@ -463,6 +471,14 @@ QColor Theme::badge(BadgeRole role, BadgeState state)
     case BadgeRole::Background:
       switch (state) {
         case BadgeState::Normal:
+        case BadgeState::Untracked:
+        case BadgeState::Added:
+        case BadgeState::Modified:
+        case BadgeState::Renamed:
+        case BadgeState::Deleted:
+        case BadgeState::Local:
+        case BadgeState::Remote:
+        case BadgeState::Tag:
           return "#A6ACB6";
 
         case BadgeState::Selected:

--- a/src/app/Theme.h
+++ b/src/app/Theme.h
@@ -31,7 +31,15 @@ public:
     Normal,
     Selected,
     Conflicted,
+    Untracked,
+    Added,
+    Modified,
+    Renamed,
+    Deleted,
     Head,
+    Local,
+    Remote,
+    Tag,
     Notification
   };
 

--- a/src/ui/Badge.h
+++ b/src/ui/Badge.h
@@ -10,6 +10,7 @@
 #ifndef BADGE_H
 #define BADGE_H
 
+#include <app/Application.h>
 #include <QWidget>
 
 class QStyleOption;
@@ -19,13 +20,12 @@ class Badge : public QWidget
 public:
   struct Label
   {
-    Label(const QString &text = QString(), bool bold = false, bool tag = false)
-      : text(text), bold(bold), tag(tag)
+    Label(const QString &text = QString(), Theme::BadgeState state = Theme::BadgeState::Normal)
+      : text(text), state(state)
     {}
 
     QString text;
-    bool bold;
-    bool tag;
+    Theme::BadgeState state;
   };
 
   Badge(const QList<Label> &labels, QWidget *parent = nullptr);

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1087,12 +1087,22 @@ private:
 
     if (mRepo.isHeadDetached()) {
       git::Reference head = mRepo.head();
-      mRefs[head.target().id()].append({head.name(), true});
+      mRefs[head.target().id()].append({head.name(), Theme::BadgeState::Head});
     }
 
     foreach (const git::Reference &ref, mRepo.refs()) {
-      if (git::Commit target = ref.target())
-        mRefs[target.id()].append({ref.name(), ref.isHead(), ref.isTag()});
+      if (git::Commit target = ref.target()) {
+        if (ref.isHead())
+          mRefs[target.id()].append({ref.name(), Theme::BadgeState::Head});
+        else if (ref.isTag())
+          mRefs[target.id()].append({ref.name(), Theme::BadgeState::Tag});
+        else if (ref.isLocalBranch())
+          mRefs[target.id()].append({ref.name(), Theme::BadgeState::Local});
+        else if (ref.isRemoteBranch())
+          mRefs[target.id()].append({ref.name(), Theme::BadgeState::Remote});
+        else
+          mRefs[target.id()].append({ref.name(), Theme::BadgeState::Normal});
+      }
     }
   }
 

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -12,6 +12,7 @@
 #include "DiffWidget.h"
 #include "MenuBar.h"
 #include "TreeWidget.h"
+#include "app/Application.h"
 #include "git/Branch.h"
 #include "git/Commit.h"
 #include "git/Diff.h"
@@ -267,7 +268,7 @@ public:
     connect(&mWatcher, &QFutureWatcher<QString>::finished, this, [this] {
       QString result = mWatcher.result();
       if (result.contains('+'))
-        mRefs->appendLabel({result, false, true});
+        mRefs->appendLabel({result, Theme::BadgeState::Tag});
     });
 
     // Respond to reference changes.
@@ -286,8 +287,18 @@ public:
   {
     QList<Badge::Label> refs;
     foreach (const git::Commit &commit, commits) {
-      foreach (const git::Reference &ref, commit.refs())
-        refs.append({ref.name(), ref.isHead(), ref.isTag()});
+      foreach (const git::Reference &ref, commit.refs()) {
+        if (ref.isHead())
+          refs.append({ref.name(), Theme::BadgeState::Head});
+        else if (ref.isTag())
+          refs.append({ref.name(), Theme::BadgeState::Tag});
+        else if (ref.isLocalBranch())
+          refs.append({ref.name(), Theme::BadgeState::Local});
+        else if (ref.isRemoteBranch())
+          refs.append({ref.name(), Theme::BadgeState::Remote});
+        else
+          refs.append({ref.name(), Theme::BadgeState::Normal});
+      }
     }
 
     mRefs->setLabels(refs);

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1630,7 +1630,7 @@ public:
 
       // Add LFS buttons.
       if (lfs) {
-        Badge *lfsBadge = new Badge({Badge::Label(FileWidget::tr("LFS"), true)}, this);
+        Badge *lfsBadge = new Badge({Badge::Label(FileWidget::tr("LFS"), Theme::BadgeState::Head)}, this);
         buttons->addWidget(lfsBadge);
 
         QToolButton *lfsLockButton = new QToolButton(this);


### PR DESCRIPTION
Solves issue #497 and issue #501.
New badge colors for CommitList: local branch, remote branch and tag.
New badge colors for DiffView: untracked, added, modified, renamed and deleted files.

The existing 'Default' and 'Dark' themes are left unchanged. The new badge colors must be uncommented to take effect:
![badge_colors](https://user-images.githubusercontent.com/67198194/93595931-e0db7980-f9b8-11ea-8188-5fd925b8dde5.png)
