### PR TITLE
Make Settings::instance() thread safe

### DIFF
--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -101,29 +101,10 @@ Settings::Settings(QObject *parent)
   mCurrentMap = mDefaults;
 }
 
-QString Settings::group() const
-{
-  return mGroup.join("/");
-}
-
-void Settings::beginGroup(const QString &prefix)
-{
-  mGroup.append(prefix);
-  mCurrentMap = lookup(mDefaults, group()).toMap();
-}
-
-void Settings::endGroup()
-{
-  mGroup.removeLast();
-  mCurrentMap = lookup(mDefaults, group()).toMap();
-}
-
 QVariant Settings::value(const QString &key) const
 {
   QSettings settings;
-  settings.beginGroup(group());
   QVariant result = settings.value(key, defaultValue(key));
-  settings.endGroup();
   return result;
 }
 
@@ -135,7 +116,6 @@ QVariant Settings::defaultValue(const QString &key) const
 void Settings::setValue(const QString &key, const QVariant &value, bool refresh)
 {
   QSettings settings;
-  settings.beginGroup(group());
   if (value == defaultValue(key)) {
     if (settings.contains(key)) {
       settings.remove(key);
@@ -147,7 +127,6 @@ void Settings::setValue(const QString &key, const QVariant &value, bool refresh)
       emit settingsChanged(refresh);
     }
   }
-  settings.endGroup();
 }
 
 QString Settings::lexer(const QString &filename)

--- a/src/conf/Settings.h
+++ b/src/conf/Settings.h
@@ -29,10 +29,6 @@ public:
     PromptLargeFiles
   };
 
-  QString group() const;
-  void beginGroup(const QString &prefix);
-  void endGroup();
-
   QVariant value(const QString &key) const;
   QVariant defaultValue(const QString &key) const;
   void setValue(const QString &key, const QVariant &value, bool refresh = false);
@@ -75,7 +71,6 @@ signals:
 private:
   Settings(QObject *parent = nullptr);
 
-  QStringList mGroup;
   QVariantMap mDefaults;
   QVariantMap mCurrentMap;
 };

--- a/src/dialogs/ConfigDialog.cpp
+++ b/src/dialogs/ConfigDialog.cpp
@@ -148,16 +148,11 @@ public:
 
     // Read defaults from global settings.
     Settings *settings = Settings::instance();
-    settings->beginGroup("global");
-    settings->beginGroup("autofetch");
-    bool fetch = settings->value("enable").toBool();
-    int minutes = settings->value("minutes").toInt();
-    settings->endGroup();
-
-    bool push = settings->value("autopush/enable").toBool();
-    bool update = settings->value("autoupdate/enable").toBool();
-    bool prune = settings->value("autoprune/enable").toBool();
-    settings->endGroup();
+    bool fetch = settings->value("global/autofetch/enable").toBool();
+    int minutes = settings->value("global/autofetch/minutes").toInt();
+    bool push = settings->value("global/autopush/enable").toBool();
+    bool update = settings->value("global/autoupdate/enable").toBool();
+    bool prune = settings->value("global/autoprune/enable").toBool();
 
     git::Config app = mRepo.appConfig();
     mFetch->setChecked(app.value<bool>("autofetch.enable", fetch));

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -200,17 +200,11 @@ public:
     mEmail->setText(config.value<QString>("user.email"));
 
     Settings *settings = Settings::instance();
-    settings->beginGroup("global");
-    settings->beginGroup("autofetch");
-    mFetch->setChecked(settings->value("enable").toBool());
-    mFetchMinutes->setValue(settings->value("minutes").toInt());
-    settings->endGroup();
-
-    mPushCommit->setChecked(settings->value("autopush/enable").toBool());
-    mPullUpdate->setChecked(settings->value("autoupdate/enable").toBool());
-    mAutoPrune->setChecked(settings->value("autoprune/enable").toBool());
-    settings->endGroup();
-
+    mFetch->setChecked(settings->value("global/autofetch/enable").toBool());
+    mFetchMinutes->setValue(settings->value("global/autofetch/minutes").toInt());
+    mPushCommit->setChecked(settings->value("global/autopush/enable").toBool());
+    mPullUpdate->setChecked(settings->value("global/autoupdate/enable").toBool());
+    mAutoPrune->setChecked(settings->value("global/autoprune/enable").toBool());
     mNoTranslation->setChecked(settings->value("translation/disable").toBool());
     mStoreCredentials->setChecked(settings->value("credential/store").toBool());
     mUsageReporting->setChecked(settings->value("tracking/enabled").toBool());
@@ -319,8 +313,6 @@ public:
     : QWidget(parent)
   {
     Settings *settings = Settings::instance();
-    settings->beginGroup("window");
-
     QComboBox *comboBox = new QComboBox(this);
 
     // default theme
@@ -355,7 +347,7 @@ public:
 
     comboBox->insertSeparator(comboBox->count());
 
-    int index = comboBox->findText(settings->value("theme").toString());
+    int index = comboBox->findText(settings->value("window/theme").toString());
 
     // add theme
     comboBox->addItem(tr("Add New Theme"));
@@ -448,31 +440,28 @@ public:
     });
 
     QCheckBox *fullPath = new QCheckBox(tr("Show full repository path"));
-    fullPath->setChecked(settings->value("path/full").toBool());
+    fullPath->setChecked(settings->value("window/path/full").toBool());
     connect(fullPath, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/path/full", checked);
     });
 
     QCheckBox *hideLog = new QCheckBox(tr("Hide automatically"));
-    hideLog->setChecked(settings->value("log/hide").toBool());
+    hideLog->setChecked(settings->value("window/log/hide").toBool());
     connect(hideLog, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/log/hide", checked);
     });
 
-    settings->beginGroup("tabs");
     QCheckBox *smTabs = new QCheckBox(tr("Open submodules in tabs"));
-    smTabs->setChecked(settings->value("submodule").toBool());
+    smTabs->setChecked(settings->value("window/tabs/submodule").toBool());
     connect(smTabs, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/tabs/submodule", checked);
     });
 
     QCheckBox *repoTabs = new QCheckBox(tr("Open all repositories in tabs"));
-    repoTabs->setChecked(settings->value("repository").toBool());
+    repoTabs->setChecked(settings->value("window/tabs/repository").toBool());
     connect(repoTabs, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/tabs/repository", checked);
     });
-    settings->endGroup(); // tabs
-    settings->endGroup(); // window
 
     QString mergeText = settings->promptDescription(Settings::PromptMerge);
     QCheckBox *merge = new QCheckBox(mergeText, this);
@@ -544,56 +533,48 @@ public:
     auto combo = QOverload<int>::of(&QComboBox::currentIndexChanged);
 
     Settings *settings = Settings::instance();
-    settings->beginGroup("editor");
-
-    settings->beginGroup("font");
     QFontComboBox *font = new QFontComboBox(this);
     font->setEditable(false);
     font->setFontFilters(QFontComboBox::MonospacedFonts);
-    font->setCurrentText(settings->value("family").toString());
+    font->setCurrentText(settings->value("editor/font/family").toString());
     connect(font, &QFontComboBox::currentTextChanged, [](const QString &text) {
       Settings::instance()->setValue("editor/font/family", text);
     });
 
     QSpinBox *fontSize = new QSpinBox(this);
     fontSize->setRange(2, 32);
-    fontSize->setValue(settings->value("size").toInt());
+    fontSize->setValue(settings->value("editor/font/size").toInt());
     connect(fontSize, spin, [](int i) {
       Settings::instance()->setValue("editor/font/size", i);
     });
-    settings->endGroup(); // font
 
-    settings->beginGroup("indent");
     QComboBox *indent = new QComboBox(this);
     indent->addItem(tr("Tabs"));
     indent->addItem(tr("Spaces"));
-    indent->setCurrentIndex(settings->value("tabs").toBool() ? 0 : 1);
+    indent->setCurrentIndex(settings->value("editor/indent/tabs").toBool() ? 0 : 1);
     connect(indent, combo, [](int i) {
       Settings::instance()->setValue("editor/indent/tabs", i == 0);
     });
 
     QSpinBox *indentWidth = new QSpinBox(this);
     indentWidth->setRange(1, 32);
-    indentWidth->setValue(settings->value("width").toInt());
+    indentWidth->setValue(settings->value("editor/indent/width").toInt());
     connect(indentWidth, spin, [](int i) {
       Settings::instance()->setValue("editor/indent/width", i);
     });
 
     QSpinBox *tabWidth = new QSpinBox(this);
     tabWidth->setRange(1, 32);
-    tabWidth->setValue(settings->value("tabwidth").toInt());
+    tabWidth->setValue(settings->value("editor/indent/tabwidth").toInt());
     connect(tabWidth, spin, [](int i) {
       Settings::instance()->setValue("editor/indent/tabwidth", i);
     });
-    settings->endGroup(); // indent
 
     QCheckBox *blameHeatMap = new QCheckBox(tr("Show heat map"), this);
-    blameHeatMap->setChecked(settings->value("blame/heatmap").toBool());
+    blameHeatMap->setChecked(settings->value("editor/blame/heatmap").toBool());
     connect(blameHeatMap, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("editor/blame/heatmap", checked);
     });
-
-    settings->endGroup(); // editor
 
     QFormLayout *layout = new QFormLayout(this);
     layout->addRow(tr("Font:"), font);
@@ -614,18 +595,16 @@ public:
     : QWidget(parent)
   {
     Settings *settings = Settings::instance();
-    settings->beginGroup("update");
-
     QString checkText = tr("Check for updates automatically");
     QCheckBox *check = new QCheckBox(checkText, this);
-    check->setChecked(settings->value("check").toBool());
+    check->setChecked(settings->value("update/check").toBool());
     connect(check, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("update/check", checked);
     });
 
     QString downloadText = tr("Automatically download and install updates");
     QCheckBox *download = new QCheckBox(downloadText, this);
-    download->setChecked(settings->value("download").toBool());
+    download->setChecked(settings->value("update/download").toBool());
     connect(download, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("update/download", checked);
     });
@@ -638,8 +617,6 @@ public:
     layout->addRow(tr("Software Update:"), check);
     layout->addRow(QString(), download);
     layout->addRow(QString(), button);
-
-    settings->endGroup();
   }
 };
 
@@ -679,21 +656,17 @@ public:
     : QWidget(parent)
   {
     Settings *settings = Settings::instance();
-    settings->beginGroup("terminal");
-
-    mNameBox = new QLineEdit(settings->value("name").toString(), this);
+    mNameBox = new QLineEdit(settings->value("terminal/name").toString(), this);
     connect(mNameBox, &QLineEdit::textChanged, [this](const QString &text) {
       Settings::instance()->setValue("terminal/name", text);
       updateInstallButton();
     });
 
-    mPathBox = new QLineEdit(settings->value("path").toString(), this);
+    mPathBox = new QLineEdit(settings->value("terminal/path").toString(), this);
     connect(mPathBox, &QLineEdit::textChanged, [this](const QString &text) {
       Settings::instance()->setValue("terminal/path", text);
       updateInstallButton();
     });
-
-    settings->endGroup();
 
     mInstallButton = new QPushButton(tr("Install"), this);
     connect(mInstallButton, &QPushButton::clicked, [this] {

--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -133,19 +133,12 @@ void TextEditor::applySettings()
 {
   // Set default font and size.
   Settings *settings = Settings::instance();
-  settings->beginGroup("editor");
-  settings->beginGroup("font");
-  QString family = settings->value("family").toString();
-  int pointSize = settings->value("size").toInt();
+  QString family = settings->value("editor/font/family").toString();
+  int pointSize = settings->value("editor/font/size").toInt();
   styleSetFont(STYLE_DEFAULT, QFont(family, pointSize));
-  settings->endGroup(); // font
-
-  settings->beginGroup("indent");
-  setUseTabs(settings->value("tabs").toBool());
-  setIndent(settings->value("width").toInt());
-  setTabWidth(settings->value("tabwidth").toInt());
-  settings->endGroup(); // indent
-  settings->endGroup(); // editor
+  setUseTabs(settings->value("editor/indent/tabs").toBool());
+  setIndent(settings->value("editor/indent/width").toInt());
+  setTabWidth(settings->value("editor/indent/tabwidth").toInt());
 
   // Initialize markers.
   markerDefine(Context, SC_MARK_EMPTY);

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -944,10 +944,8 @@ void RepoView::startFetchTimer()
 
   // Read defaults from global settings.
   Settings *settings = Settings::instance();
-  settings->beginGroup("global/autofetch");
-  bool enable = settings->value("enable").toBool();
-  int minutes = settings->value("minutes").toInt();
-  settings->endGroup();
+  bool enable = settings->value("global/autofetch/enable").toBool();
+  int minutes = settings->value("global/autofetch/minutes").toInt();
 
   git::Config config = mRepo.appConfig();
   if (!config.value<bool>("autofetch.enable", enable))

--- a/src/update/UpdateDialog.cpp
+++ b/src/update/UpdateDialog.cpp
@@ -79,11 +79,10 @@ UpdateDialog::UpdateDialog(
   connect(buttons, &QDialogButtonBox::rejected, this, &UpdateDialog::reject);
   connect(skip, &QPushButton::clicked, [this, version] {
     Settings *settings = Settings::instance();
-    settings->beginGroup("update");
-    QStringList skipped = settings->value("skip").toStringList();
+    QStringList skipped = settings->value("update/skip").toStringList();
     if (!skipped.contains(version))
-      settings->setValue("skip", skipped << version);
-    settings->endGroup();
+      settings->setValue("update/skip", skipped << version);
+
     reject();
   });
 


### PR DESCRIPTION
Removed `beginGroup()` and `endGroup()` functions.

I stumbled over these [editor] settings:
![settings](https://user-images.githubusercontent.com/67198194/94368878-e89ccb80-00e6-11eb-83f5-6f43ca45bf63.png)
(2 entrys for the same setting)