### PR TITLE
FreeBSD Build: Detect location of libinotify using FindPkgConfig

### DIFF
--- a/src/watcher/CMakeLists.txt
+++ b/src/watcher/CMakeLists.txt
@@ -3,6 +3,15 @@ if(APPLE)
   set(WATCHER_IMPL_LIBS "-framework CoreServices")
 elseif(WIN32)
   set(WATCHER_IMPL_FILE RepositoryWatcher_win.cpp)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  # if we're in FreeBSD then we can use the linux inotify watcher
+  # but... we need the libinotify bridge to kqueue, so we need to find this
+  include(FindPkgConfig)
+  pkg_check_modules(LIBINOTIFY REQUIRED libinotify)
+
+  set(WATCHER_IMPL_LIBS ${LIBINOTIFY_LINK_LIBRARIES})
+  set(WATCHER_IMPL_INC_DIRS ${LIBINOTIFY_INCLUDE_DIRS})
+  set(WATCHER_IMPL_FILE RepositoryWatcher_linux.cpp)
 else()
   set(WATCHER_IMPL_FILE RepositoryWatcher_linux.cpp)
 endif()
@@ -14,6 +23,7 @@ add_library(watcher
 
 target_include_directories(watcher PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}
+  ${WATCHER_IMPL_INC_DIRS}
 )
 
 target_link_libraries(watcher


### PR DESCRIPTION
When building on FreeBSD, libinotify wasn't in the expected location based on the linux paths.
Using pkg_check_modules to detect the library and header locations for libinotify appeared to work however.