### PR TITLE
Add saving log to disk

### DIFF
--- a/src/dialogs/CloneDialog.cpp
+++ b/src/dialogs/CloneDialog.cpp
@@ -258,7 +258,7 @@ public:
     setSubTitle(tr("The new repository will open after the clone finishes."));
 
     mLogRoot = new LogEntry(this);
-    mLogView = new LogView(mLogRoot, this);
+    mLogView = new LogView(mLogRoot, nullptr, this);
     connect(mLogView, &LogView::operationCanceled, this, &ClonePage::cancel);
 
     QVBoxLayout *layout = new QVBoxLayout(this);

--- a/src/dialogs/ConfigDialog.cpp
+++ b/src/dialogs/ConfigDialog.cpp
@@ -97,6 +97,15 @@ public:
     mPullUpdate = new QCheckBox(tr("Update submodules after pull"), this);
     mAutoPrune = new QCheckBox(tr("Prune when fetching"), this);
 
+    mMaxLogEntrys = new QSpinBox(this);
+    mMaxLogEntrys->setRange(3, 300);
+
+    QHBoxLayout *logLayout = new QHBoxLayout;
+    logLayout->addWidget(new QLabel(tr("Retain")));
+    logLayout->addWidget(mMaxLogEntrys);
+    logLayout->addWidget(new QLabel(tr("entrys")));
+    logLayout->addStretch();
+
     QFormLayout *form = new QFormLayout(this);
     form->addRow(tr("User name:"), mName);
     form->addRow(tr("User email:"), mEmail);
@@ -104,6 +113,7 @@ public:
     form->addRow(QString(), mPushCommit);
     form->addRow(QString(), mPullUpdate);
     form->addRow(QString(), mAutoPrune);
+    form->addRow(tr("Logging:"), logLayout);
 
     init();
 
@@ -138,6 +148,10 @@ public:
     connect(mAutoPrune, &QCheckBox::toggled, [this](bool checked) {
       mRepo.appConfig().setValue("autoprune.enable", checked);
     });
+
+    connect(mMaxLogEntrys, signal, [this](int value) {
+      mRepo.appConfig().setValue("log.maxentrys", value);
+    });
   }
 
   void init()
@@ -165,6 +179,7 @@ public:
     mPushCommit->setChecked(app.value<bool>("autopush.enable", push));
     mPullUpdate->setChecked(app.value<bool>("autoupdate.enable", update));
     mAutoPrune->setChecked(app.value<bool>("autoprune.enable", prune));
+    mMaxLogEntrys->setValue(app.value<int>("log.maxentrys", 300));
   }
 
 private:
@@ -177,6 +192,7 @@ private:
   QCheckBox *mPushCommit;
   QCheckBox *mPullUpdate;
   QCheckBox *mAutoPrune;
+  QSpinBox *mMaxLogEntrys;
 };
 
 class RemotesPanel : public QWidget

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -115,6 +115,16 @@ public:
     mPushCommit = new QCheckBox(tr("Push after each commit"), this);
     mPullUpdate = new QCheckBox(tr("Update submodules after pull"), this);
     mAutoPrune = new QCheckBox(tr("Prune when fetching"), this);
+
+    mMaxLogEntrys = new QSpinBox(this);
+    mMaxLogEntrys->setRange(3, 300);
+
+    QHBoxLayout *logLayout = new QHBoxLayout;
+    logLayout->addWidget(new QLabel(tr("Retain")));
+    logLayout->addWidget(mMaxLogEntrys);
+    logLayout->addWidget(new QLabel(tr("entrys")));
+    logLayout->addStretch();
+
     mNoTranslation = new QCheckBox(tr("No translation"), this);
 
     mStoreCredentials = new QCheckBox(
@@ -134,6 +144,7 @@ public:
     form->addRow(QString(), mPushCommit);
     form->addRow(QString(), mPullUpdate);
     form->addRow(QString(), mAutoPrune);
+    form->addRow(tr("Logging:"), logLayout);
     form->addRow(tr("Language:"), mNoTranslation);
     form->addRow(tr("Credentials:"), mStoreCredentials);
     form->addRow(tr("Usage reporting:"), mUsageReporting);
@@ -179,6 +190,10 @@ public:
       Settings::instance()->setValue("global/autoprune/enable", checked);
     });
 
+    connect(mMaxLogEntrys, signal, [](int value) {
+      git::Config::appGlobal().setValue("log.maxentrys", value);
+    });
+
     connect(mNoTranslation, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("translation/disable", checked);
     });
@@ -214,6 +229,9 @@ public:
     mNoTranslation->setChecked(settings->value("translation/disable").toBool());
     mStoreCredentials->setChecked(settings->value("credential/store").toBool());
     mUsageReporting->setChecked(settings->value("tracking/enabled").toBool());
+
+    git::Config app = git::Config::appGlobal();
+    mMaxLogEntrys->setValue(app.value<int>("log.maxentrys", 300));
   }
 
 private:
@@ -225,6 +243,7 @@ private:
   QCheckBox *mPushCommit;
   QCheckBox *mPullUpdate;
   QCheckBox *mAutoPrune;
+  QSpinBox *mMaxLogEntrys;
   QCheckBox *mNoTranslation;
   QCheckBox *mStoreCredentials;
   QCheckBox *mUsageReporting;

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(loglib
 )
 
 target_link_libraries(loglib
+  git
   Qt5::Widgets
 )
 

--- a/src/log/LogEntry.cpp
+++ b/src/log/LogEntry.cpp
@@ -17,11 +17,10 @@ LogEntry::LogEntry(
   Kind kind,
   const QString &text,
   const QString &title,
+  const QDateTime &timestamp,
   LogEntry *parent)
-  : QObject(parent), mKind(kind), mText(text), mTitle(title)
+  : QObject(parent), mKind(kind), mText(text), mTitle(title), mTimestamp(timestamp)
 {
-  mTimestamp = QDateTime::currentDateTime();
-
   // Connect progress timer.
   connect(&mTimer, &QTimer::timeout, [this] {
     ++mProgress;
@@ -58,9 +57,9 @@ LogEntry *LogEntry::addEntry(Kind kind, const QString &text)
   return insertEntry(mEntries.size(), kind, text);
 }
 
-LogEntry *LogEntry::addEntry(const QString &text, const QString &title)
+LogEntry *LogEntry::addEntry(const QString &text, const QString &title, const QDateTime &timestamp)
 {
-  return insertEntry(mEntries.size(), Entry, text, title);
+  return insertEntry(mEntries.size(), Entry, text, title, timestamp);
 }
 
 void LogEntry::insertEntries(int row, const QList<LogEntry *> &entries)
@@ -81,11 +80,30 @@ LogEntry *LogEntry::insertEntry(
   int row,
   Kind kind,
   const QString &text,
-  const QString &title)
+  const QString &title,
+  const QDateTime &timestamp)
 {
-  LogEntry *entry = new LogEntry(kind, text, title, this);
+  LogEntry *entry = new LogEntry(kind, text, title, timestamp, this);
   insertEntries(row, {entry});
   return entry;
+}
+
+void LogEntry::delEntry(const LogEntry *entry)
+{
+  for (int i = 0; i < mEntries.size(); ++i) {
+    if (entry == mEntries.at(i)) {
+      removeEntry(i);
+      break;
+    }
+  }
+}
+
+void LogEntry::removeEntry(int row)
+{
+  LogEntry *root = rootEntry();
+  emit root->entriesAboutToBeRemoved(this, row, mEntries.size());
+  mEntries.removeAt(row);
+  emit root->entriesRemoved();
 }
 
 void LogEntry::setBusy(bool busy)

--- a/src/log/LogEntry.h
+++ b/src/log/LogEntry.h
@@ -34,6 +34,7 @@ public:
     Kind kind,
     const QString &text,
     const QString &title,
+    const QDateTime &timestamp = QDateTime::currentDateTime(),
     LogEntry *parent = nullptr);
 
   Kind kind() const { return mKind; }
@@ -54,14 +55,21 @@ public:
 
   void addEntries(const QList<LogEntry *> &entries);
   LogEntry *addEntry(Kind kind, const QString &text);
-  LogEntry *addEntry(const QString &text, const QString &title = QString());
+  LogEntry *addEntry(
+    const QString &text,
+    const QString &title = QString(),
+    const QDateTime &timestamp = QDateTime::currentDateTime());
 
   void insertEntries(int row, const QList<LogEntry *> &entries);
   LogEntry *insertEntry(
     int row,
     Kind kind,
     const QString &text,
-    const QString &title = QString());
+    const QString &title = QString(),
+    const QDateTime &timestamp = QDateTime::currentDateTime());
+
+  void delEntry(const LogEntry *entry);
+  void removeEntry(int row);
 
   int progress() const { return mProgress; }
   void setBusy(bool busy);
@@ -71,6 +79,8 @@ signals:
   void entriesAboutToBeInserted(LogEntry *entry, int row, int count = 1);
   void entriesInserted();
   void errorInserted();
+  void entriesAboutToBeRemoved(LogEntry *entry, int row, int count = 1);
+  void entriesRemoved();
 
 private:
   Kind mKind = Entry;

--- a/src/log/LogModel.cpp
+++ b/src/log/LogModel.cpp
@@ -36,6 +36,13 @@ LogModel::LogModel(LogEntry *root, QStyle *style, QObject *parent)
     QModelIndex index = this->index(entry);
     emit dataChanged(index, index, {Qt::DisplayRole});
   });
+
+  connect(root, &LogEntry::entriesAboutToBeRemoved,
+  [this](LogEntry *entry, int row, int count) {
+    beginRemoveRows(index(entry), row, row + count - 1);
+  });
+
+  connect(root, &LogEntry::entriesRemoved, this, &LogModel::endRemoveRows);
 }
 
 QModelIndex LogModel::index(

--- a/src/log/LogView.cpp
+++ b/src/log/LogView.cpp
@@ -11,13 +11,26 @@
 #include "LogDelegate.h"
 #include "LogEntry.h"
 #include "LogModel.h"
+#include "git/Config.h"
 #include <QAction>
 #include <QApplication>
 #include <QAbstractTextDocumentLayout>
 #include <QClipboard>
+#include <QFileDialog>
 #include <QHeaderView>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
 #include <QMimeData>
 #include <QMouseEvent>
+
+const int kIndentSpaces = 4;
+const int kSaveDelay = 1000;
+
+const int kDefaultIndent = 1;
+const int kDefaultKind = 0;
+const int kDefaultStatus = 0;
 
 namespace {
 
@@ -37,10 +50,35 @@ QModelIndexList collectSelectedIndexes(
   return selection;
 }
 
+QModelIndexList collectIndexes(
+  QTreeView *view,
+  const QModelIndex &parent)
+{
+  QModelIndexList selection;
+  QAbstractItemModel *model = view->model();
+  for (int i = 0; i < model->rowCount(parent); ++i) {
+    QModelIndex index = model->index(i, 0, parent);
+    selection.append(index);
+    selection.append(collectIndexes(view, index));
+  }
+  return selection;
+}
+
+QModelIndex lastRootIndex(
+  QTreeView *view,
+  const QModelIndex &parent)
+{
+  QAbstractItemModel *model = view->model();
+  int i = model->rowCount(parent) - 1;
+  return model->index(i, 0, parent);
+}
+
 } // anon. namespace
 
-LogView::LogView(LogEntry *root, QWidget *parent)
-  : QTreeView(parent)
+LogView::LogView(LogEntry *root,
+                 const git::Repository *repo,
+                 QWidget *parent)
+  : QTreeView(parent), mRoot(root)
 {
   setMouseTracking(true);
   setHeaderHidden(true);
@@ -51,10 +89,40 @@ LogView::LogView(LogEntry *root, QWidget *parent)
   header->setStretchLastSection(false);
   header->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-  QAction *copyAction = new QAction(tr("Copy"), this);
-  addAction(copyAction);
+  mCopyAction = new QAction(tr("Copy Selection to Clipboard"), this);
+  mCopyAction->setEnabled(false);
+  addAction(mCopyAction);
+  connect(mCopyAction, &QAction::triggered, [this] {
+    copy(true);
+  });
 
-  connect(copyAction, &QAction::triggered, this, &LogView::copy);
+  QAction *copyAllAction = new QAction(tr("Copy Log to Clipboard"), this);
+  copyAllAction->setEnabled(false);
+  addAction(copyAllAction);
+  connect(copyAllAction, &QAction::triggered, [this] {
+    copy(false);
+  });
+
+  mClearAction = new QAction(tr("Clear Selection"), this);
+  mClearAction->setEnabled(false);
+  addAction(mClearAction);
+  connect(mClearAction, &QAction::triggered, [this] {
+    clear(true);
+  });
+
+  QAction *clearAllAction = new QAction(tr("Clear Log"), this);
+  clearAllAction->setEnabled(false);
+  addAction(clearAllAction);
+  connect(clearAllAction, &QAction::triggered, [this] {
+    clear(false);
+  });
+
+  QAction *saveAction = new QAction(tr("Save Log as..."), this);
+  saveAction->setEnabled(false);
+  addAction(saveAction);
+  connect(saveAction, &QAction::triggered, [this] {
+    save(true);
+  });
 
   LogModel *model = new LogModel(root, style(), this);
   LogDelegate *delegate = new LogDelegate(this);
@@ -65,11 +133,53 @@ LogView::LogView(LogEntry *root, QWidget *parent)
   setItemDelegate(delegate);
 
   connect(model, &QAbstractItemModel::rowsInserted,
-  [this](const QModelIndex &parent, int first, int last) {
+  [this, copyAllAction, clearAllAction, saveAction](const QModelIndex &parent, int first, int last) {
     if (!parent.isValid() && mCollapse)
       collapse(this->model()->index(last - 1, 0, parent));
-    scrollTo(this->model()->index(last, 0, parent)); 
+    scrollTo(this->model()->index(last, 0, parent));
+
+    copyAllAction->setEnabled(true);
+    clearAllAction->setEnabled(true);
+    saveAction->setEnabled(true);
+
+    if (mRepo.isValid()) {
+      // Max log entrys.
+      while (this->model()->rowCount() > mRepo.appConfig().value<int>("log.maxentrys", 300))
+        mRoot->removeEntry(0);
+
+      mLogTimer.start(kSaveDelay);
+    }
   });
+
+  connect(model, &QAbstractItemModel::rowsRemoved,
+  [this, copyAllAction, clearAllAction, saveAction](const QModelIndex &parent, int first, int last) {
+    if (this->model()->rowCount() == 0) {
+      copyAllAction->setEnabled(false);
+      clearAllAction->setEnabled(false);
+      saveAction->setEnabled(false);
+    }
+
+    if (mRepo.isValid())
+      mLogTimer.start(kSaveDelay);
+  });
+
+  // Repository is valid.
+  if (repo != nullptr) {
+    mRepo = *repo;
+
+    // Load log.
+    load();
+
+    // Save log on data change.
+    connect(model, &QAbstractItemModel::dataChanged,
+    [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) {
+      mLogTimer.start(kSaveDelay);
+    });
+    connect(&mLogTimer, &QTimer::timeout, [this] {
+      mLogTimer.stop();
+      save();
+    });
+  }
 }
 
 void LogView::setCollapseEnabled(bool collapse) 
@@ -82,24 +192,34 @@ void LogView::setEntryExpanded(LogEntry *entry, bool expanded)
   setExpanded(static_cast<LogModel *>(model())->index(entry), expanded);
 }
 
-void LogView::copy() 
+void LogView::copy(bool selection)
 {
   QString plainText;
   QString richText;
-  QModelIndexList indexes = collectSelectedIndexes(this, QModelIndex());
+  QModelIndexList indexes;
+
+  if (selection)
+    indexes = collectSelectedIndexes(this, QModelIndex());
+  else
+    indexes = collectIndexes(this, QModelIndex());
+
   foreach (const QModelIndex &index, indexes) {
     QString prefix;
 
-    //Indent child indices
+    // Indent child indices.
     QModelIndex currentParent = index.parent();
     while (currentParent.isValid()){
-      prefix += QString(4, ' ');
+      prefix += QString(kIndentSpaces, ' ');
       currentParent = currentParent.parent();
     }
 
-    //Add expansion indicator
-    if (this->model()->hasChildren(index))
-      prefix += isExpanded(index) ? "[-]" : "[+]";
+    // Add expansion indicator.
+    if (this->model()->hasChildren(index)) {
+      if (selection)
+        prefix += isExpanded(index) ? "[-]" : "[+]";
+      else
+        prefix += "[-]";
+    }
 
     QString text = index.data().toString();
     plainText += QString("%1 %2\n").arg(prefix, text.remove(QRegExp("<[^>]*>")));
@@ -112,6 +232,146 @@ void LogView::copy()
   mimeDate->setText(plainText);
   mimeDate->setHtml(richText);
   QApplication::clipboard()->setMimeData(mimeDate);
+}
+
+void LogView::clear(bool selection)
+{
+  QModelIndexList indexes;
+  if (selection)
+    indexes = collectSelectedIndexes(this, QModelIndex());
+  else
+    indexes = collectIndexes(this, QModelIndex());
+
+  for (int i = indexes.count() - 1; i >= 0; i--)
+    mRoot->removeEntry(indexes[i].row());
+}
+
+void LogView::load()
+{
+  if (!mRepo.isValid())
+    return;
+
+  // Load log.
+  QJsonDocument jsondoc;
+  QFile log(mRepo.dir().filePath("gitahead/log.json"));
+  if (log.open(QIODevice::ReadOnly)) {
+    jsondoc = QJsonDocument::fromJson(log.readAll());
+    log.close();
+  }
+  if (jsondoc.isEmpty())
+    return;
+
+  // Disable save() timer and clear log.
+  mLogTimer.blockSignals(true);
+  clear(false);
+
+  LogEntry *entry = nullptr;
+  int indent = 0;
+  QJsonArray jsonarr = jsondoc.array();
+  foreach (const QJsonValue &jsonval, jsonarr) {
+    QJsonObject json = jsonval.toObject();
+
+    if (json.contains("timestamp")) {
+      QDateTime timestamp = QDateTime::fromString(json["timestamp"].toString(), Qt::ISODate);
+      QString title = json["title"].toString();
+      QString text = json["text"].toString();
+      entry = mRoot->addEntry(text, title, timestamp);
+      indent = 1;
+
+    } else if (indent > 0) {
+      int childindent = json["indent"].toInt(kDefaultIndent);
+      LogEntry::Kind kind = static_cast<LogEntry::Kind>(json["kind"].toInt(kDefaultKind));
+      char status = json["status"].toInt(kDefaultStatus);
+      QString text = json["text"].toString();
+
+      while ((indent > childindent) && (entry->parentEntry() != mRoot)) {
+        entry = entry->parentEntry();
+        indent--;
+      }
+
+      entry = entry->addEntry(kind, text);
+      entry->setStatus(status);
+      indent += 1;
+    }
+
+    // Collapse entry.
+    if (indent > 0)
+      setEntryExpanded(entry->parentEntry(), false);
+  }
+
+  // Max log entrys.
+  while (this->model()->rowCount() > mRepo.appConfig().value<int>("log.maxentrys", 300))
+    mRoot->removeEntry(0);
+
+  // Reset and restart save() timer.
+  mLogTimer.stop();
+  mLogTimer.blockSignals(false);
+}
+
+void LogView::save(bool as)
+{
+  QString filename;
+
+  if (as) {
+    QStringList filter = { tr("Text Log (*.json)"), tr("Binary Log (*.dat)") };
+    filename = QFileDialog::getSaveFileName(nullptr,
+                                            tr("Save Log"),
+                                            QDir::homePath() + "/log.json",
+                                            filter.join(";;"),
+                                            &filter.first());
+  } else if (mRepo.isValid()) {
+    filename = mRepo.dir().filePath("gitahead/log.json");
+  }
+  if (filename.isEmpty())
+    return;
+
+  // Last entry is busy.
+  QModelIndex last = lastRootIndex(this, QModelIndex());
+  if (last.isValid()) {
+    LogEntry *entry = static_cast<LogEntry *>(last.internalPointer());
+    if (entry->progress() >= 0)
+      return;
+  }
+
+  QJsonArray jsonarr;
+  QModelIndexList indexes = collectIndexes(this, QModelIndex());
+  foreach (const QModelIndex &index, indexes) {
+    LogEntry *entry = static_cast<LogEntry *>(index.internalPointer());
+    QModelIndex currentParent = index.parent();
+    QJsonObject json;
+
+    if (!currentParent.isValid()) {
+      json.insert("timestamp", entry->timestamp().toString(Qt::ISODate));
+      json.insert("title", entry->title());
+    } else {
+      int indent = 0;
+      while (currentParent.isValid()) {
+        indent += 1;
+        currentParent = currentParent.parent();
+      }
+      if (indent != kDefaultIndent)
+        json.insert("indent", indent);
+      if (entry->kind() != kDefaultKind)
+        json.insert("kind", entry->kind());
+      if (entry->status() != kDefaultStatus)
+        json.insert("status", entry->status());
+    }
+    json.insert("text", entry->text());
+    jsonarr.append(json);
+  }
+
+  // Save log.
+  if (!jsonarr.isEmpty()) {
+    QJsonDocument jsondoc(jsonarr);
+    QFile log(filename);
+    if (log.open(QIODevice::WriteOnly)) {
+      if (filename.endsWith(".dat"))
+        log.write(jsondoc.toBinaryData());
+      else
+        log.write(jsondoc.toJson());
+      log.close();
+    }
+  }
 }
 
 QSize LogView::minimumSizeHint() const
@@ -174,6 +434,15 @@ void LogView::mouseReleaseEvent(QMouseEvent *event)
   }
 
   QTreeView::mouseReleaseEvent(event);
+}
+
+void LogView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
+{
+  bool enable = !selected.isEmpty();
+  mCopyAction->setEnabled(enable);
+  mClearAction->setEnabled(enable);
+
+  QTreeView::selectionChanged(selected, deselected);
 }
 
 QString LogView::linkAt(const QModelIndex &index, const QPoint &pos)

--- a/src/log/LogView.h
+++ b/src/log/LogView.h
@@ -10,6 +10,8 @@
 #ifndef LOGVIEW_H
 #define LOGVIEW_H
 
+#include "git/Repository.h"
+#include <QTimer>
 #include <QTreeView>
 
 class LogEntry;
@@ -19,11 +21,18 @@ class LogView : public QTreeView
   Q_OBJECT
 
 public:
-  LogView(LogEntry *root, QWidget *parent = nullptr);
+  LogView(LogEntry *root,
+          const git::Repository *repo,
+          QWidget *parent = nullptr);
 
   QSize minimumSizeHint() const override;
 
-  void copy();
+  void copy(bool selection = true);
+  void clear(bool selection = true);
+
+  void load();
+  void save(bool as = false);
+
   void setCollapseEnabled(bool collapse); 
 
   void setEntryExpanded(LogEntry *entry, bool expanded);
@@ -36,14 +45,21 @@ protected:
   void mouseMoveEvent(QMouseEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
+  void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 
 private:
   QString linkAt(const QModelIndex &index, const QPoint &pos);
   bool isDecoration(const QModelIndex &index, const QPoint &pos);
 
+  LogEntry *mRoot;
+  git::Repository mRepo;
   QString mLink;
   QModelIndex mCancel;
   bool mCollapse = true;
+
+  QAction *mCopyAction;
+  QAction *mClearAction;
+  QTimer mLogTimer;
 };
 
 #endif

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -387,7 +387,7 @@ RepoView::RepoView(const git::Repository &repo, MainWindow *parent)
   connect(mLogRoot, &LogEntry::errorInserted,
           this, &RepoView::suspendLogTimer);
 
-  mLogView = new LogView(mLogRoot, this);
+  mLogView = new LogView(mLogRoot, &repo, this);
   connect(mLogView, &LogView::linkActivated,
           this, &RepoView::visitLink);
   connect(mLogView, &LogView::operationCanceled,


### PR DESCRIPTION
The log is stored in the local .git/gitahead folder (like the index).
The logfile is a simple json file with 1 array entry for every log line.

The whole logfile is saved after every log change (insertion or deletion).
The number of entrys in the log / logfile is configurable in the `SettingsDialog` (global)
and `ConfigDialog` (local repository):
![log_entrys](https://user-images.githubusercontent.com/67198194/95652226-df9cf880-0aef-11eb-9eb5-e8a03c2c14af.png)
Range = 3 to 300

The context menu for the log:
![log](https://user-images.githubusercontent.com/67198194/95652250-f80d1300-0aef-11eb-871b-391355b0121a.png)
Save As...: Save the logfile in json text or json binary format to the choosen destination.

json text format:
![log_json](https://user-images.githubusercontent.com/67198194/95652341-841f3a80-0af0-11eb-8956-7ebfe9b65dda.png)

Solves #13