### PR TITLE
Revise ConfigDialog and SettingsDialog

### DIFF
--- a/src/dialogs/DiffPanel.cpp
+++ b/src/dialogs/DiffPanel.cpp
@@ -14,29 +14,62 @@
 #include "ui/MainWindow.h"
 #include "ui/RepoView.h"
 #include <QApplication>
-#include <QCheckBox>
-#include <QComboBox>
 #include <QFormLayout>
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QPushButton>
-#include <QSpinBox>
 #include <QTextCodec>
 
 DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
-  : QWidget(parent), mConfig(repo ? repo.config() : git::Config::global())
+  : QWidget(parent), mConfig(repo ? repo.config() : git::Config::global()),
+                     mAppConfig(repo ? repo.appConfig() : git::Config::appGlobal())
 {
-  // diff context
-  QSpinBox *context = new QSpinBox(this);
+  bool global = repo ? false : true;
+
+  // Diff context.
+  mContext = new QSpinBox(this);
   QLabel *contextLabel = new QLabel(tr("lines"), this);
   QHBoxLayout *contextLayout = new QHBoxLayout;
-  contextLayout->addWidget(context);
+  contextLayout->addWidget(mContext);
   contextLayout->addWidget(contextLabel);
   contextLayout->addStretch();
-  context->setValue(mConfig.value<int>("diff.context", 3));
 
+  // Encoding.
+  mEncoding = new QComboBox(this);
+  mEncoding->addItem(tr("System Locale"), -1);
+  mEncoding->insertSeparator(mEncoding->count());
+  foreach (int mib, QTextCodec::availableMibs())
+    mEncoding->addItem(QTextCodec::codecForMib(mib)->name(), mib);
+
+  QFormLayout *layout = new QFormLayout(this);
+  layout->addRow(tr("Context lines:"), contextLayout);
+  layout->addRow(tr("Character Encoding:"), mEncoding);
+
+  // Remaining settings are strictly global.
+  if (global) {
+    QFrame *line = new QFrame(this);
+    line->setFrameShape(QFrame::HLine);
+    layout->addRow(QString(), line);
+
+    // ignore whitespace
+    // The ignore whitespace option is global because it's
+    // not a config setting. It's a flag (-w) to git diff.
+    mIgnoreWs = new QCheckBox(tr("Ignore Whitespace (-w)"), this);
+
+    // Auto collapse diff view.
+    mCollapseAdded = new QCheckBox(tr("Added files"), this);
+    mCollapseDeleted = new QCheckBox(tr("Deleted files"), this);
+
+    layout->addRow(tr("Whitespace:"), mIgnoreWs);
+    layout->addRow(tr("Auto Collapse:"), mCollapseAdded);
+    layout->addRow(QString(), mCollapseDeleted);
+  }
+
+  refresh();
+
+  // Connect signals after initializing fields.
   auto contextSignal = QOverload<int>::of(&QSpinBox::valueChanged);
-  connect(context, contextSignal, [this](int value) {
+  connect(mContext, contextSignal, [this](int value) {
     mConfig.setValue("diff.context", value);
     foreach (MainWindow *window, MainWindow::windows()) {
       for (int i = 0; i < window->count(); ++i)
@@ -44,23 +77,12 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
     }
   });
 
-  // encoding
-  QComboBox *encoding = new QComboBox(this);
-  encoding->addItem(tr("System Locale"), -1);
-  encoding->insertSeparator(encoding->count());
-  foreach (int mib, QTextCodec::availableMibs())
-    encoding->addItem(QTextCodec::codecForMib(mib)->name(), mib);
-
-  QString name = mConfig.value<QString>("gui.encoding");
-  if (!name.isEmpty())
-    encoding->setCurrentIndex(encoding->findText(name));
-
   auto encodingSignal = QOverload<int>::of(&QComboBox::currentIndexChanged);
-  connect(encoding, encodingSignal, [this, encoding](int index) {
-    if (encoding->itemData(index).toInt() < 0) {
+  connect(mEncoding, encodingSignal, [this](int index) {
+    if (mEncoding->itemData(index).toInt() < 0) {
       mConfig.remove("gui.encoding");
     } else {
-      mConfig.setValue("gui.encoding", encoding->itemText(index));
+      mConfig.setValue("gui.encoding", mEncoding->itemText(index));
     }
 
     foreach (MainWindow *window, MainWindow::windows()) {
@@ -69,38 +91,34 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
     }
   });
 
-  QFormLayout *layout = new QFormLayout(this);
-  layout->addRow(tr("Context lines:"), contextLayout);
-  layout->addRow(tr("Character Encoding:"), encoding);
+  if (global) {
+    connect(mIgnoreWs, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setWhitespaceIgnored(checked);
+    });
 
-  // Remaining settings are strictly global.
-  if (qobject_cast<ConfigDialog *>(parent))
+    connect(mCollapseAdded, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setValue("collapse/added", checked);
+    });
+
+    connect(mCollapseDeleted, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setValue("collapse/deleted", checked);
+    });
+  }
+}
+
+void DiffPanel::refresh(void)
+{
+  mContext->setValue(mConfig.value<int>("diff.context", 3));
+
+  QString name = mConfig.value<QString>("gui.encoding");
+  if (!name.isEmpty())
+    mEncoding->setCurrentIndex(mEncoding->findText(name));
+
+  if (mIgnoreWs == nullptr)
     return;
 
-  // ignore whitespace
-  // The ignore whitespace option is global because it's
-  // not a config setting. It's a flag (-w) to git diff.
-  QCheckBox *ignoreWs = new QCheckBox(tr("Ignore Whitespace (-w)"), this);
-  ignoreWs->setChecked(Settings::instance()->isWhitespaceIgnored());
-  connect(ignoreWs, &QCheckBox::toggled, [](bool checked) {
-    Settings::instance()->setWhitespaceIgnored(checked);
-  });
+  mIgnoreWs->setChecked(Settings::instance()->isWhitespaceIgnored());
 
-  // auto collapse
-  Settings *settings = Settings::instance();
-  QCheckBox *collapseAdded = new QCheckBox(tr("Added files"), this);
-  collapseAdded->setChecked(settings->value("collapse/added").toBool());
-  connect(collapseAdded, &QCheckBox::toggled, [settings](bool checked) {
-    settings->setValue("collapse/added", checked);
-  });
-
-  QCheckBox *collapseDeleted = new QCheckBox(tr("Deleted files"), this);
-  collapseDeleted->setChecked(settings->value("collapse/deleted").toBool());
-  connect(collapseDeleted, &QCheckBox::toggled, [settings](bool checked) {
-    settings->setValue("collapse/deleted", checked);
-  });
-
-  layout->addRow(tr("Whitespace:"), ignoreWs);
-  layout->addRow(tr("Auto Collapse:"), collapseAdded);
-  layout->addRow(QString(), collapseDeleted);
+  mCollapseAdded->setChecked(Settings::instance()->value("collapse/added").toBool());
+  mCollapseDeleted->setChecked(Settings::instance()->value("collapse/deleted").toBool());
 }

--- a/src/dialogs/DiffPanel.h
+++ b/src/dialogs/DiffPanel.h
@@ -11,6 +11,9 @@
 #define DIFFPANEL_H
 
 #include "git/Config.h"
+#include <QCheckBox>
+#include <QComboBox>
+#include <QSpinBox>
 #include <QWidget>
 
 class QHBoxLayout;
@@ -22,8 +25,19 @@ class DiffPanel : public QWidget
 public:
   DiffPanel(const git::Repository &repo, QWidget *parent = nullptr);
 
+  void refresh(void);
+
 private:
   git::Config mConfig;
+  git::Config mAppConfig;
+
+  QSpinBox *mContext;
+  QComboBox *mEncoding;
+
+  QCheckBox *mIgnoreWs = nullptr;
+
+  QCheckBox *mCollapseAdded;
+  QCheckBox *mCollapseDeleted;
 };
 
 #endif

--- a/src/dialogs/PluginsPanel.h
+++ b/src/dialogs/PluginsPanel.h
@@ -24,10 +24,10 @@ public:
 
   PluginsPanel(const git::Repository &repo, QWidget *parent = nullptr);
 
+  void refresh();
+
   QSize sizeHint() const override;
 
 private:
-  void refresh();
-
   git::Repository mRepo;
 };

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -41,11 +41,13 @@
 #include <QProcess>
 #include <QPushButton>
 #include <QSaveFile>
+#include <QSettings>
 #include <QShortcut>
 #include <QSpinBox>
 #include <QStackedWidget>
 #include <QStandardItemModel>
 #include <QToolBar>
+#include <QToolButton>
 
 #ifdef Q_OS_UNIX
 #include "cli/Installer.h"
@@ -143,7 +145,7 @@ public:
     layout->setContentsMargins(16,12,16,12);
     layout->addLayout(form);
 
-    init();
+    refresh();
 
     // Connect signals after initializing fields.
     connect(mName, &QLineEdit::textChanged, [](const QString &text) {
@@ -193,24 +195,18 @@ public:
     });
   }
 
-  void init()
+  void refresh()
   {
     git::Config config = git::Config::global();
     mName->setText(config.value<QString>("user.name"));
     mEmail->setText(config.value<QString>("user.email"));
 
     Settings *settings = Settings::instance();
-    settings->beginGroup("global");
-    settings->beginGroup("autofetch");
-    mFetch->setChecked(settings->value("enable").toBool());
-    mFetchMinutes->setValue(settings->value("minutes").toInt());
-    settings->endGroup();
-
-    mPushCommit->setChecked(settings->value("autopush/enable").toBool());
-    mPullUpdate->setChecked(settings->value("autoupdate/enable").toBool());
-    mAutoPrune->setChecked(settings->value("autoprune/enable").toBool());
-    settings->endGroup();
-
+    mFetch->setChecked(settings->value("global/autofetch/enable").toBool());
+    mFetchMinutes->setValue(settings->value("global/autofetch/minutes").toInt());
+    mPushCommit->setChecked(settings->value("global/autopush/enable").toBool());
+    mPullUpdate->setChecked(settings->value("global/autoupdate/enable").toBool());
+    mAutoPrune->setChecked(settings->value("global/autoprune/enable").toBool());
     mNoTranslation->setChecked(settings->value("translation/disable").toBool());
     mStoreCredentials->setChecked(settings->value("credential/store").toBool());
     mUsageReporting->setChecked(settings->value("tracking/enabled").toBool());
@@ -238,10 +234,26 @@ public:
   ToolsPanel(QWidget *parent = nullptr)
     : QWidget(parent), mConfig(git::Config::global())
   {
-    // external editor
-    QLineEdit *editTool = new QLineEdit(this);
-    editTool->setText(mConfig.value<QString>("gui.editor"));
-    connect(editTool, &QLineEdit::textChanged, [this](const QString &text) {
+    // External editor.
+    mEditTool = new QLineEdit(this);
+
+    // External diff/merge.
+    mDiffTool = externalTools("diff");
+    mMergeTool = externalTools("merge");
+
+    // Backup files.
+    mBackup = new QCheckBox(tr("Keep backup of merge files (.orig)"), this);
+
+    QFormLayout *layout = new QFormLayout(this);
+    layout->addRow(tr("External editor:"), mEditTool);
+    layout->addRow(tr("External diff:"), mDiffTool);
+    layout->addRow(tr("External merge:"), mMergeTool);
+    layout->addRow(tr("Backup files:"), mBackup);
+
+    refresh();
+
+    // Connect signals after initializing fields.
+    connect(mEditTool, &QLineEdit::textChanged, [this](const QString &text) {
       if (text.isEmpty()) {
         mConfig.remove("gui.editor");
       } else {
@@ -249,23 +261,30 @@ public:
       }
     });
 
-    // external diff/merge
-    QHBoxLayout *diffTool = externalTools("diff");
-    QHBoxLayout *mergeTool = externalTools("merge");
-
-    // backup files
-    QCheckBox *backup =
-      new QCheckBox(tr("Keep backup of merge files (.orig)"), this);
-    backup->setChecked(mConfig.value<bool>("mergetool.keepBackup"));
-    connect(backup, &QCheckBox::toggled, [this](bool checked) {
+    connect(mBackup, &QCheckBox::toggled, [this](bool checked) {
       mConfig.setValue("mergetool.keepBackup", checked);
     });
+  }
 
-    QFormLayout *layout = new QFormLayout(this);
-    layout->addRow(tr("External editor:"), editTool);
-    layout->addRow(tr("External diff:"), diffTool);
-    layout->addRow(tr("External merge:"), mergeTool);
-    layout->addRow(tr("Backup files:"), backup);
+  void refresh(void)
+  {
+    QComboBox *comboBox;
+    QString key;
+    QString name;
+
+    mEditTool->setText(mConfig.value<QString>("gui.editor"));
+
+    comboBox = static_cast<QComboBox *>(mDiffTool->itemAt(0)->widget());
+    key = QString("%1.tool").arg("diff");
+    name = mConfig.value<QString>(key);
+    comboBox->setCurrentIndex(comboBox->findText(name));
+
+    comboBox = static_cast<QComboBox *>(mMergeTool->itemAt(0)->widget());
+    key = QString("%1.tool").arg("merge");
+    name = mConfig.value<QString>(key);
+    comboBox->setCurrentIndex(comboBox->findText(name));
+
+    mBackup->setChecked(mConfig.value<bool>("mergetool.keepBackup"));
   }
 
 private:
@@ -277,8 +296,6 @@ private:
 
     // Read tool from git config.
     QString key = QString("%1.tool").arg(type);
-    QString name = mConfig.value<QString>(key);
-    comboBox->setCurrentIndex(comboBox->findText(name));
 
     // React to combo box selections.
     auto signal = QOverload<int>::of(&QComboBox::currentIndexChanged);
@@ -308,6 +325,11 @@ private:
   }
 
   git::Config mConfig;
+
+  QLineEdit *mEditTool;
+  QHBoxLayout *mDiffTool;
+  QHBoxLayout *mMergeTool;
+  QCheckBox *mBackup;
 };
 
 class WindowPanel : public QWidget
@@ -318,15 +340,12 @@ public:
   WindowPanel(QWidget *parent = nullptr)
     : QWidget(parent)
   {
-    Settings *settings = Settings::instance();
-    settings->beginGroup("window");
+    mComboBox = new QComboBox(this);
 
-    QComboBox *comboBox = new QComboBox(this);
+    // Default theme.
+    mComboBox->addItem("Default");
 
-    // default theme
-    comboBox->addItem("Default");
-
-    // predefined themes
+    // Predefined themes.
     QDir dir = Settings::themesDir();
     dir.setNameFilters({"*.lua"});
     QDirIterator *it = new QDirIterator(dir);
@@ -334,10 +353,10 @@ public:
       it->next();
       QString name = it->fileInfo().baseName();
       if (name != "Default")
-        comboBox->addItem(name);
+        mComboBox->addItem(name);
     }
 
-    // user themes
+    // User themes.
     bool exists = false;
     QDir appLocalDir = CustomTheme::userDir(false, &exists);
     if (exists) {
@@ -345,36 +364,62 @@ public:
       QDirIterator *it = new QDirIterator(appLocalDir);
 
       if (it->hasNext())
-        comboBox->insertSeparator(comboBox->count());
+        mComboBox->insertSeparator(mComboBox->count());
 
       while (it->hasNext()) {
         it->next();
-        comboBox->addItem(it->fileInfo().baseName(), it->filePath());
+        mComboBox->addItem(it->fileInfo().baseName(), it->filePath());
       }
     }
 
-    comboBox->insertSeparator(comboBox->count());
+    mComboBox->insertSeparator(mComboBox->count());
 
-    int index = comboBox->findText(settings->value("theme").toString());
+    Settings *settings = Settings::instance();
+    int index = mComboBox->findText(settings->value("window/theme").toString());
 
-    // add theme
-    comboBox->addItem(tr("Add New Theme"));
-    comboBox->addItem(tr("Edit Current Theme"), index);
+    // Add theme.
+    mComboBox->addItem(tr("Add New Theme"));
+    mComboBox->addItem(tr("Edit Current Theme"), index);
+    mComboBox->setCurrentIndex(index >= 0 ? index : 0);
 
-    // Select the current theme.
-    comboBox->setCurrentIndex(index >= 0 ? index : 0);
-
-    // Edit enabled for user themes
+    // Edit enabled for user themes.
     QStandardItemModel *model =
-      static_cast<QStandardItemModel *>(comboBox->model());
-    if(!comboBox->itemData(comboBox->currentIndex()).isValid())
-      model->item(comboBox->count() - 1)->setEnabled(false);
+      static_cast<QStandardItemModel *>(mComboBox->model());
+    if(!mComboBox->itemData(mComboBox->currentIndex()).isValid())
+      model->item(mComboBox->count() - 1)->setEnabled(false);
 
+    mFullPath = new QCheckBox(tr("Show full repository path"));
+    mHideLog = new QCheckBox(tr("Hide automatically"));
+    mSubTabs = new QCheckBox(tr("Open submodules in tabs"));
+    mRepoTabs = new QCheckBox(tr("Open all repositories in tabs"));
+    mMerge = new QCheckBox(this);
+    mRevert = new QCheckBox(this);
+    mCherryPick = new QCheckBox(this);
+    mStash = new QCheckBox(this);
+    mLargeFiles = new QCheckBox(this);
+    mDirectories = new QCheckBox(this);
+
+    QFormLayout *layout = new QFormLayout(this);
+    layout->addRow(tr("Theme:"), mComboBox);
+    layout->addRow(tr("Title:"), mFullPath);
+    layout->addRow(tr("Log:"), mHideLog);
+    layout->addRow(tr("Tabs:"), mSubTabs);
+    layout->addRow(QString(), mRepoTabs);
+    layout->addRow(tr("Prompt:"), mMerge);
+    layout->addRow(QString(), mRevert);
+    layout->addRow(QString(), mCherryPick);
+    layout->addRow(QString(), mStash);
+    layout->addRow(QString(), mDirectories);
+    layout->addRow(QString(), mLargeFiles);
+
+    refresh();
+
+    // Connect signals after initializing fields.
     auto signal = QOverload<int>::of(&QComboBox::currentIndexChanged);
-    connect(comboBox, signal, [this, parent, comboBox] {
+    connect(mComboBox, signal, [this, parent] {
 
-      //Add new theme
-      if (comboBox->currentIndex() == comboBox->count() - 2) {
+      // Add new theme.
+      if (mComboBox->currentIndex() == mComboBox->count() - 2) {
         QDialog dialog;
 
         QDialogButtonBox *buttons =
@@ -406,22 +451,22 @@ public:
         return;
       }
 
-      //Edit current theme
+      // Edit current theme.
       QStandardItemModel *model =
-        static_cast<QStandardItemModel *>(comboBox->model());
-      bool enabled = comboBox->itemData(comboBox->currentIndex()).isValid();
-      model->item(comboBox->count() - 1)->setEnabled(enabled);
+        static_cast<QStandardItemModel *>(mComboBox->model());
+      bool enabled = mComboBox->itemData(mComboBox->currentIndex()).isValid();
+      model->item(mComboBox->count() - 1)->setEnabled(enabled);
 
-      if (comboBox->currentIndex() == comboBox->count() - 1) {
-        int index = comboBox->currentData().toInt();
-        QString path = comboBox->itemData(index).toString();
+      if (mComboBox->currentIndex() == mComboBox->count() - 1) {
+        int index = mComboBox->currentData().toInt();
+        QString path = mComboBox->itemData(index).toString();
         EditorWindow::open(path);
         parent->close();
         return;
       }
 
-      //Save theme
-      Settings::instance()->setValue("window/theme", comboBox->currentText());
+      // Save theme.
+      Settings::instance()->setValue("window/theme", mComboBox->currentText());
 
       QMessageBox mb(QMessageBox::Information, tr("Restart?"),
         tr("The application must be restarted for "
@@ -447,89 +492,95 @@ public:
       }
     });
 
-    QCheckBox *fullPath = new QCheckBox(tr("Show full repository path"));
-    fullPath->setChecked(settings->value("path/full").toBool());
-    connect(fullPath, &QCheckBox::toggled, [](bool checked) {
+    connect(mFullPath, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/path/full", checked);
     });
 
-    QCheckBox *hideLog = new QCheckBox(tr("Hide automatically"));
-    hideLog->setChecked(settings->value("log/hide").toBool());
-    connect(hideLog, &QCheckBox::toggled, [](bool checked) {
+    connect(mHideLog, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/log/hide", checked);
     });
 
-    settings->beginGroup("tabs");
-    QCheckBox *smTabs = new QCheckBox(tr("Open submodules in tabs"));
-    smTabs->setChecked(settings->value("submodule").toBool());
-    connect(smTabs, &QCheckBox::toggled, [](bool checked) {
+    connect(mSubTabs, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/tabs/submodule", checked);
     });
 
-    QCheckBox *repoTabs = new QCheckBox(tr("Open all repositories in tabs"));
-    repoTabs->setChecked(settings->value("repository").toBool());
-    connect(repoTabs, &QCheckBox::toggled, [](bool checked) {
+    connect(mRepoTabs, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("window/tabs/repository", checked);
     });
-    settings->endGroup(); // tabs
-    settings->endGroup(); // window
 
-    QString mergeText = settings->promptDescription(Settings::PromptMerge);
-    QCheckBox *merge = new QCheckBox(mergeText, this);
-    merge->setChecked(settings->prompt(Settings::PromptMerge));
-    connect(merge, &QCheckBox::toggled, [](bool checked) {
+    connect(mMerge, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptMerge, checked);
     });
 
-    QString revertText = settings->promptDescription(Settings::PromptRevert);
-    QCheckBox *revert = new QCheckBox(revertText, this);
-    revert->setChecked(settings->prompt(Settings::PromptRevert));
-    connect(revert, &QCheckBox::toggled, [](bool checked) {
+    connect(mRevert, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptRevert, checked);
     });
 
-    QString cpText = settings->promptDescription(Settings::PromptCherryPick);
-    QCheckBox *cherryPick = new QCheckBox(cpText, this);
-    cherryPick->setChecked(settings->prompt(Settings::PromptCherryPick));
-    connect(cherryPick, &QCheckBox::toggled, [](bool checked) {
+    connect(mCherryPick, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptCherryPick, checked);
     });
 
-    QString stashText = settings->promptDescription(Settings::PromptStash);
-    QCheckBox *stash = new QCheckBox(stashText, this);
-    stash->setChecked(settings->prompt(Settings::PromptStash));
-    connect(stash, &QCheckBox::toggled, [](bool checked) {
+    connect(mStash, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptStash, checked);
     });
 
-    QString largeFilesText = settings->promptDescription(Settings::PromptLargeFiles);
-    QCheckBox *largeFiles = new QCheckBox(largeFilesText, this);
-    largeFiles->setChecked(settings->prompt(Settings::PromptLargeFiles));
-    connect(largeFiles, &QCheckBox::toggled, [](bool checked) {
+    connect(mLargeFiles, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptLargeFiles, checked);
     });
 
-    QString directoriesText = settings->promptDescription(Settings::PromptDirectories);
-    QCheckBox *directories = new QCheckBox(directoriesText, this);
-    directories->setChecked(settings->prompt(Settings::PromptDirectories));
-    connect(directories, &QCheckBox::toggled, [](bool checked) {
+    connect(mDirectories, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setPrompt(Settings::PromptDirectories, checked);
     });
-
-    QFormLayout *layout = new QFormLayout(this);
-
-    layout->addRow(tr("Theme:"), comboBox);
-    layout->addRow(tr("Title:"), fullPath);
-    layout->addRow(tr("Log:"), hideLog);
-    layout->addRow(tr("Tabs:"), smTabs);
-    layout->addRow(QString(), repoTabs);
-    layout->addRow(tr("Prompt:"), merge);
-    layout->addRow(QString(), revert);
-    layout->addRow(QString(), cherryPick);
-    layout->addRow(QString(), stash);
-    layout->addRow(QString(), directories);
-    layout->addRow(QString(), largeFiles);
   }
+
+  void refresh(void)
+  {
+    Settings *settings = Settings::instance();
+    int index = mComboBox->findText(settings->value("window/theme").toString());
+    mComboBox->setCurrentIndex(index >= 0 ? index : 0);
+
+    mFullPath->setChecked(settings->value("window/path/full").toBool());
+    mHideLog->setChecked(settings->value("window/log/hide").toBool());
+    mSubTabs->setChecked(settings->value("window/tabs/submodule").toBool());
+    mRepoTabs->setChecked(settings->value("window/tabs/repository").toBool());
+
+    QString mergeText = settings->promptDescription(Settings::PromptMerge);
+    mMerge->setText(mergeText);
+    mMerge->setChecked(settings->prompt(Settings::PromptMerge));
+
+    QString revertText = settings->promptDescription(Settings::PromptRevert);
+    mRevert->setText(revertText);
+    mRevert->setChecked(settings->prompt(Settings::PromptRevert));
+
+    QString cpText = settings->promptDescription(Settings::PromptCherryPick);
+    mCherryPick->setText(cpText);
+    mCherryPick->setChecked(settings->prompt(Settings::PromptCherryPick));
+
+    QString stashText = settings->promptDescription(Settings::PromptStash);
+    mStash->setText(stashText);
+    mStash->setChecked(settings->prompt(Settings::PromptStash));
+
+    QString largeFilesText = settings->promptDescription(Settings::PromptLargeFiles);
+    mLargeFiles->setText(largeFilesText);
+    mLargeFiles->setChecked(settings->prompt(Settings::PromptLargeFiles));
+
+    QString directoriesText = settings->promptDescription(Settings::PromptDirectories);
+    mDirectories->setText(directoriesText);
+    mDirectories->setChecked(settings->prompt(Settings::PromptDirectories));
+  }
+
+private:
+  QComboBox *mComboBox;
+  QCheckBox *mFullPath;
+  QCheckBox *mHideLog;
+  QCheckBox *mSubTabs;
+  QCheckBox *mRepoTabs;
+  QCheckBox *mMerge;
+  QCheckBox *mRevert;
+  QCheckBox *mCherryPick;
+  QCheckBox *mStash;
+  QCheckBox *mLargeFiles;
+  QCheckBox *mDirectories;
 };
 
 class EditorPanel : public QWidget
@@ -543,66 +594,79 @@ public:
     auto spin = QOverload<int>::of(&QSpinBox::valueChanged);
     auto combo = QOverload<int>::of(&QComboBox::currentIndexChanged);
 
-    Settings *settings = Settings::instance();
-    settings->beginGroup("editor");
+    mFont = new QFontComboBox(this);
+    mFont->setEditable(false);
 
-    settings->beginGroup("font");
-    QFontComboBox *font = new QFontComboBox(this);
-    font->setEditable(false);
-    font->setFontFilters(QFontComboBox::MonospacedFonts);
-    font->setCurrentText(settings->value("family").toString());
-    connect(font, &QFontComboBox::currentTextChanged, [](const QString &text) {
+    mFontSize = new QSpinBox(this);
+    mFontSize->setRange(2, 32);
+
+    mIndent = new QComboBox(this);
+    mIndent->addItem(tr("Tabs"));
+    mIndent->addItem(tr("Spaces"));
+
+    mIndentWidth = new QSpinBox(this);
+    mIndentWidth->setRange(1, 32);
+
+    mTabWidth = new QSpinBox(this);
+    mTabWidth->setRange(1, 32);
+
+    mBlameHeatMap = new QCheckBox(tr("Show heat map"), this);
+
+    QFormLayout *layout = new QFormLayout(this);
+    layout->addRow(tr("Font:"), mFont);
+    layout->addRow(tr("Font size:"), mFontSize);
+    layout->addRow(tr("Indent using:"), mIndent);
+    layout->addRow(tr("Indent width:"), mIndentWidth);
+    layout->addRow(tr("Tab width:"), mTabWidth);
+    layout->addRow(tr("Blame margin:"), mBlameHeatMap);
+
+    refresh();
+
+    // Connect signals after initializing fields.
+    mFont->setFontFilters(QFontComboBox::MonospacedFonts);
+    connect(mFont, &QFontComboBox::currentTextChanged, [](const QString &text) {
       Settings::instance()->setValue("editor/font/family", text);
     });
 
-    QSpinBox *fontSize = new QSpinBox(this);
-    fontSize->setRange(2, 32);
-    fontSize->setValue(settings->value("size").toInt());
-    connect(fontSize, spin, [](int i) {
+    connect(mFontSize, spin, [](int i) {
       Settings::instance()->setValue("editor/font/size", i);
     });
-    settings->endGroup(); // font
 
-    settings->beginGroup("indent");
-    QComboBox *indent = new QComboBox(this);
-    indent->addItem(tr("Tabs"));
-    indent->addItem(tr("Spaces"));
-    indent->setCurrentIndex(settings->value("tabs").toBool() ? 0 : 1);
-    connect(indent, combo, [](int i) {
+    connect(mIndent, combo, [](int i) {
       Settings::instance()->setValue("editor/indent/tabs", i == 0);
     });
 
-    QSpinBox *indentWidth = new QSpinBox(this);
-    indentWidth->setRange(1, 32);
-    indentWidth->setValue(settings->value("width").toInt());
-    connect(indentWidth, spin, [](int i) {
+    connect(mIndentWidth, spin, [](int i) {
       Settings::instance()->setValue("editor/indent/width", i);
     });
 
-    QSpinBox *tabWidth = new QSpinBox(this);
-    tabWidth->setRange(1, 32);
-    tabWidth->setValue(settings->value("tabwidth").toInt());
-    connect(tabWidth, spin, [](int i) {
+    connect(mTabWidth, spin, [](int i) {
       Settings::instance()->setValue("editor/indent/tabwidth", i);
     });
-    settings->endGroup(); // indent
 
-    QCheckBox *blameHeatMap = new QCheckBox(tr("Show heat map"), this);
-    blameHeatMap->setChecked(settings->value("blame/heatmap").toBool());
-    connect(blameHeatMap, &QCheckBox::toggled, [](bool checked) {
+    connect(mBlameHeatMap, &QCheckBox::toggled, [](bool checked) {
       Settings::instance()->setValue("editor/blame/heatmap", checked);
     });
-
-    settings->endGroup(); // editor
-
-    QFormLayout *layout = new QFormLayout(this);
-    layout->addRow(tr("Font:"), font);
-    layout->addRow(tr("Font size:"), fontSize);
-    layout->addRow(tr("Indent using:"), indent);
-    layout->addRow(tr("Indent width:"), indentWidth);
-    layout->addRow(tr("Tab width:"), tabWidth);
-    layout->addRow(tr("Blame margin:"), blameHeatMap);
   }
+
+  void refresh(void)
+  {
+    Settings *settings = Settings::instance();
+    mFont->setCurrentText(settings->value("editor/font/family").toString());
+    mFontSize->setValue(settings->value("editor/font/size").toInt());
+    mIndent->setCurrentIndex(settings->value("editor/indent/tabs").toBool() ? 0 : 1);
+    mIndentWidth->setValue(settings->value("editor/indent/width").toInt());
+    mTabWidth->setValue(settings->value("editor/indent/tabwidth").toInt());
+    mBlameHeatMap->setChecked(settings->value("editor/blame/heatmap").toBool());
+  }
+
+private:
+  QFontComboBox *mFont;
+  QSpinBox *mFontSize;
+  QComboBox *mIndent;
+  QSpinBox *mIndentWidth;
+  QSpinBox *mTabWidth;
+  QCheckBox *mBlameHeatMap;
 };
 
 class UpdatePanel : public QWidget
@@ -613,34 +677,43 @@ public:
   UpdatePanel(QWidget *parent = nullptr)
     : QWidget(parent)
   {
-    Settings *settings = Settings::instance();
-    settings->beginGroup("update");
-
     QString checkText = tr("Check for updates automatically");
-    QCheckBox *check = new QCheckBox(checkText, this);
-    check->setChecked(settings->value("check").toBool());
-    connect(check, &QCheckBox::toggled, [](bool checked) {
-      Settings::instance()->setValue("update/check", checked);
-    });
+    mCheck = new QCheckBox(checkText, this);
 
     QString downloadText = tr("Automatically download and install updates");
-    QCheckBox *download = new QCheckBox(downloadText, this);
-    download->setChecked(settings->value("download").toBool());
-    connect(download, &QCheckBox::toggled, [](bool checked) {
-      Settings::instance()->setValue("update/download", checked);
-    });
+    mDownload = new QCheckBox(downloadText, this);
 
     QPushButton *button = new QPushButton(tr("Check Now"), this);
     connect(button, &QPushButton::clicked,
             Updater::instance(), &Updater::update);
 
     QFormLayout *layout = new QFormLayout(this);
-    layout->addRow(tr("Software Update:"), check);
-    layout->addRow(QString(), download);
+    layout->addRow(tr("Software Update:"), mCheck);
+    layout->addRow(QString(), mDownload);
     layout->addRow(QString(), button);
 
-    settings->endGroup();
+    refresh();
+
+    // Connect signals after initializing fields.
+    connect(mCheck, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setValue("update/check", checked);
+    });
+
+    connect(mDownload, &QCheckBox::toggled, [](bool checked) {
+      Settings::instance()->setValue("update/download", checked);
+    });
   }
+
+  void refresh(void)
+  {
+    Settings *settings = Settings::instance();
+    mCheck->setChecked(settings->value("update/check").toBool());
+    mDownload->setChecked(settings->value("update/download").toBool());
+  }
+
+private:
+  QCheckBox *mCheck;
+  QCheckBox *mDownload;
 };
 
 class MiscPanel : public QWidget
@@ -651,22 +724,35 @@ public:
   MiscPanel(QWidget *parent = nullptr)
     : QWidget(parent)
   {
-    Settings *settings = Settings::instance();
+    mSshConfigPathBox = new QLineEdit(this);
+    mSshKeyPathBox = new QLineEdit(this);
 
-    QLineEdit *sshConfigPathBox = new QLineEdit(settings->value("ssh/configFilePath").toString(), this);
-    connect(sshConfigPathBox, &QLineEdit::textChanged, [](const QString &text) {
+    QFormLayout *layout = new QFormLayout(this);
+    layout->addRow(tr("Path to SSH config file:"), mSshConfigPathBox);
+    layout->addRow(tr("Path to default / fallback SSH key file:"), mSshKeyPathBox);
+
+    refresh();
+
+    // Connect signals after initializing fields.
+    connect(mSshConfigPathBox, &QLineEdit::textChanged, [](const QString &text) {
       Settings::instance()->setValue("ssh/configFilePath", text);
     });
 
-    QLineEdit *sshKeyPathBox = new QLineEdit(settings->value("ssh/keyFilePath").toString(), this);
-    connect(sshKeyPathBox, &QLineEdit::textChanged, [](const QString &text) {
+    connect(mSshKeyPathBox, &QLineEdit::textChanged, [](const QString &text) {
       Settings::instance()->setValue("ssh/keyFilePath", text);
     });
-
-    QFormLayout *layout = new QFormLayout(this);
-    layout->addRow(tr("Path to SSH config file:"), sshConfigPathBox);
-    layout->addRow(tr("Path to default / fallback SSH key file:"), sshKeyPathBox);
   }
+
+  void refresh(void)
+  {
+    Settings *settings = Settings::instance();
+    mSshConfigPathBox->setText(settings->value("ssh/configFilePath").toString());
+    mSshKeyPathBox->setText(settings->value("ssh/keyFilePath").toString());
+  }
+
+private:
+  QLineEdit *mSshConfigPathBox;
+  QLineEdit *mSshKeyPathBox;
 };
 
 #ifdef Q_OS_UNIX
@@ -679,21 +765,18 @@ public:
     : QWidget(parent)
   {
     Settings *settings = Settings::instance();
-    settings->beginGroup("terminal");
 
-    mNameBox = new QLineEdit(settings->value("name").toString(), this);
+    mNameBox = new QLineEdit(settings->value("terminal/name").toString(), this);
     connect(mNameBox, &QLineEdit::textChanged, [this](const QString &text) {
       Settings::instance()->setValue("terminal/name", text);
       updateInstallButton();
     });
 
-    mPathBox = new QLineEdit(settings->value("path").toString(), this);
+    mPathBox = new QLineEdit(settings->value("terminal/path").toString(), this);
     connect(mPathBox, &QLineEdit::textChanged, [this](const QString &text) {
       Settings::instance()->setValue("terminal/path", text);
       updateInstallButton();
     });
-
-    settings->endGroup();
 
     mInstallButton = new QPushButton(tr("Install"), this);
     connect(mInstallButton, &QPushButton::clicked, [this] {
@@ -756,7 +839,7 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
           this, &SettingsDialog::adjustSize);
 
   QString text =
-    tr("Global git settings can be overridden for each repository in "
+    tr("Global git and GitAhead settings can be overridden for each repository in "
        "the corresponding repository configuration page.");
   QLabel *description = new QLabel(text, this);
   description->setStyleSheet("QLabel { padding: 0px 20px 0px 20px }");
@@ -768,14 +851,25 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   description->setFont(small);
 #endif
 
-  QDialogButtonBox *buttons =
-    new QDialogButtonBox(QDialogButtonBox::Ok, this);
+  QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok, this);
   connect(buttons, &QDialogButtonBox::accepted, this, &SettingsDialog::close);
   connect(buttons, &QDialogButtonBox::rejected, this, &SettingsDialog::close);
 
-  // Add edit button.
-  QPushButton *edit =
-    buttons->addButton(tr("Edit Config File..."), QDialogButtonBox::ResetRole);
+  // Add edit menu.
+  QToolButton *edit = new QToolButton(this);
+  edit->setPopupMode(QToolButton::InstantPopup);
+  edit->setText(tr("Edit Config File..."));
+
+  QMenu *editMenu = new QMenu(edit);
+  QAction *editGit = editMenu->addAction(tr("Edit git Config File"));
+  QAction *editGitAhead = editMenu->addAction(tr("Edit GitAhead Config File"));
+  QAction *editGlobal = editMenu->addAction(tr("Edit GitAhead Global Settings"));
+#ifndef Q_OS_LINUX
+  editGlobal->setVisible(false);
+#endif
+  edit->setMenu(editMenu);
+
+  buttons->addButton(edit, QDialogButtonBox::ResetRole);
 
   QWidget *widget = new QWidget(this);
   QVBoxLayout *layout = new QVBoxLayout(widget);
@@ -793,11 +887,16 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   // Track actions in a group.
   QActionGroup *actions = new QActionGroup(this);
   connect(actions, &QActionGroup::triggered,
-  [this, stack, description, edit](QAction *action) {
+  [this, stack, description, editGit, editGitAhead, editGlobal](QAction *action) {
     int index = action->data().toInt();
-    bool config = (index < Window);
-    description->setVisible(config);
-    edit->setVisible(config);
+    bool gitconfig = (index < Window);
+    bool gitaheadconfig = (index == General || index == Diff || index == Plugins);
+    bool gitaheadsetting = (index != Tools && index != Plugins);
+
+    description->setVisible(gitconfig || gitaheadconfig);
+    editGit->setEnabled(gitconfig);
+    editGitAhead->setEnabled(gitaheadconfig);
+    editGlobal->setEnabled(gitaheadsetting);
     stack->setCurrentIndex(index);
     setWindowTitle(action->text());
   });
@@ -808,7 +907,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   general->setActionGroup(actions);
   general->setCheckable(true);
 
-  stack->addWidget(new GeneralPanel(this));
+  GeneralPanel *generalPanel = new GeneralPanel(this);
+  stack->addWidget(generalPanel);
 
   // Add diff panel.
   QAction *diff = toolbar->addAction(QIcon(":/diff.png"), tr("Diff"));
@@ -816,7 +916,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   diff->setActionGroup(actions);
   diff->setCheckable(true);
 
-  stack->addWidget(new DiffPanel(git::Repository(), this));
+  DiffPanel *diffPanel = new DiffPanel(git::Repository(), this);
+  stack->addWidget(diffPanel);
 
   // Add tools panel.
   QAction *tools = toolbar->addAction(QIcon(":/tools.png"), tr("Tools"));
@@ -824,7 +925,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   tools->setActionGroup(actions);
   tools->setCheckable(true);
 
-  stack->addWidget(new ToolsPanel(this));
+  ToolsPanel *toolsPanel = new ToolsPanel(this);
+  stack->addWidget(toolsPanel);
 
   toolbar->addSeparator();
 
@@ -834,7 +936,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   window->setActionGroup(actions);
   window->setCheckable(true);
 
-  stack->addWidget(new WindowPanel(this));
+  WindowPanel *windowPanel = new WindowPanel(this);
+  stack->addWidget(windowPanel);
 
   // Add editor panel.
   QAction *editor = toolbar->addAction(QIcon(":/editor.png"), tr("Editor"));
@@ -842,7 +945,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   editor->setActionGroup(actions);
   editor->setCheckable(true);
 
-  stack->addWidget(new EditorPanel(this));
+  EditorPanel *editorPanel = new EditorPanel(this);
+  stack->addWidget(editorPanel);
 
   // Add update panel.
   QAction *update = toolbar->addAction(QIcon(":/update.png"), tr("Update"));
@@ -850,7 +954,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   update->setActionGroup(actions);
   update->setCheckable(true);
 
-  stack->addWidget(new UpdatePanel(this));
+  UpdatePanel *updatePanel = new UpdatePanel(this);
+  stack->addWidget(updatePanel);
 
   // Add plugins panel.
   QAction *plugins = toolbar->addAction(QIcon(":/plugins.png"), tr("Plugins"));
@@ -858,7 +963,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   plugins->setActionGroup(actions);
   plugins->setCheckable(true);
 
-  stack->addWidget(new PluginsPanel(git::Repository(), this));
+  PluginsPanel *pluginsPanel = new PluginsPanel(git::Repository(), this);
+  stack->addWidget(pluginsPanel);
 
   // Add misc panel.
   QAction *misc = toolbar->addAction(QIcon(":/misc.png"), tr("Misc"));
@@ -866,7 +972,8 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   misc->setActionGroup(actions);
   misc->setCheckable(true);
 
-  stack->addWidget(new MiscPanel(this));
+  MiscPanel *miscPanel = new MiscPanel(this);
+  stack->addWidget(miscPanel);
 
 #ifdef Q_OS_UNIX
   // Add terminal panel.
@@ -878,13 +985,47 @@ SettingsDialog::SettingsDialog(Index index, QWidget *parent)
   stack->addWidget(new TerminalPanel(this));
 #endif
 
-  // Hook up edit button.
-  connect(edit, &QPushButton::clicked, stack, [stack] {
+  // Hook up git config edit.
+  connect(editGit, &QAction::triggered, [generalPanel, diffPanel, toolsPanel] {
     // Update on save.
     EditorWindow *window = EditorWindow::open(git::Config::globalPath());
-    GeneralPanel *panel = static_cast<GeneralPanel *>(stack->widget(General));
-    connect(window->widget(), &BlameEditor::saved, panel, &GeneralPanel::init);
+    connect(window->widget(), &BlameEditor::saved, [generalPanel, diffPanel, toolsPanel] {
+      // GitAhead Config changed.
+      generalPanel->refresh();
+      diffPanel->refresh();
+      toolsPanel->refresh();
+    });
   });
+
+  // Hook up app config edit.
+  connect(editGitAhead, &QAction::triggered, [generalPanel, diffPanel, pluginsPanel] {
+    // Update on save.
+    EditorWindow *window = EditorWindow::open(Settings::userDir().path() + "/config");
+    connect(window->widget(), &BlameEditor::saved, [generalPanel, diffPanel, pluginsPanel] {
+      // GitAhead config changed.
+      generalPanel->refresh();
+      diffPanel->refresh();
+      pluginsPanel->refresh();
+    });
+  });
+
+#ifdef Q_OS_LINUX
+  // Hook up app settings edit.
+  connect(editGlobal, &QAction::triggered, [generalPanel, diffPanel, windowPanel, editorPanel, updatePanel, miscPanel] {
+    // Update on save.
+    QSettings settings;
+    EditorWindow *window = EditorWindow::open(settings.fileName());
+    connect(window->widget(), &BlameEditor::saved, [generalPanel, diffPanel, windowPanel, editorPanel, updatePanel, miscPanel] {
+      // Gitahead settings changed.
+      generalPanel->refresh();
+      diffPanel->refresh();
+      windowPanel->refresh();
+      editorPanel->refresh();
+      updatePanel->refresh();
+      miscPanel->refresh();
+    });
+  });
+#endif
 
   // Select the requested index.
   actions->actions().at(index)->trigger();


### PR DESCRIPTION
The dialog content is updated after editing the GitAhead configuration file.
New action to discard the local GitAhead configuration.

`SettingsDialog` example:
![global_diff](https://user-images.githubusercontent.com/67198194/96339827-45145a80-1097-11eb-8d86-b52264c6dfef.png)
Linux users are able to edit the global GitAhead (application) settings - a textfile is used as storage.
Windows: the registry is used for the global GitAhead settings
Apple: I have no idea...

`ConfigDialog` example:
![repo_diff](https://user-images.githubusercontent.com/67198194/96339833-4d6c9580-1097-11eb-8539-0c3562b36e76.png)
Discarding the local GitAhead configuration will bring back the global GitAhead configuration.