### PR TITLE
Create dedicated update patch functions

### DIFF
--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1511,6 +1511,10 @@ public:
     setFont(font);
   }
 
+  void setName(const QString& name) {
+      mName = name;
+  }
+
   void setOldName(const QString &oldName)
   {
     mOldName = oldName;

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1857,7 +1857,6 @@ public:
     }
 
     bool lfs = patch.isLfsPointer();
-
     mHeader = new Header(diff, patch, binary, lfs, submodule, parent);
     layout->addWidget(mHeader);
 
@@ -1900,28 +1899,11 @@ public:
       return;
     }
 
-    // Add untracked file content.
-    if (patch.isUntracked()) {
-      if (!QFileInfo(path).isDir())
-        layout->addWidget(addHunk(diff, patch, -1, lfs, submodule));
-      return;
-    }
 
-    // Generate a diff between the head tree and index.
-    QSet<int> stagedHunks;
-    if (staged.isValid()) {
-      for (int i = 0; i < staged.count(); ++i)
-        stagedHunks.insert(staged.lineNumber(i, 0, git::Diff::OldFile));
-    }
+    mHunkLayout = new QVBoxLayout();
+    layout->addLayout(mHunkLayout);
 
-    // Add diff hunks.
-    int hunkCount = patch.count();
-    for (int hidx = 0; hidx < hunkCount; ++hidx) {
-      HunkWidget *hunk = addHunk(diff, patch, hidx, lfs, submodule);
-      int startLine = patch.lineNumber(hidx, 0, git::Diff::OldFile);
-      hunk->header()->check()->setChecked(stagedHunks.contains(startLine));
-      layout->addWidget(hunk);
-    }
+    updatePatch(patch, staged);
 
     // LFS
     if (QToolButton *lfsButton = mHeader->lfsButton()) {
@@ -1958,6 +1940,45 @@ public:
   bool isEmpty()
   {
     return (mHunks.isEmpty() && mImages.isEmpty());
+  }
+
+  void updatePatch(const git::Patch &patch, const git::Patch &staged) {
+    mHeader->updatePatch(patch);
+
+    git::Repository repo = RepoView::parentView(this)->repo();
+
+    QString name = patch.name();
+    QString path = repo.workdir().filePath(name);
+    bool submodule = repo.lookupSubmodule(name).isValid();
+    bool lfs = patch.isLfsPointer();
+
+    // remove all hunks
+    QLayoutItem *child;
+    while ((child = mHunkLayout->takeAt(0)) != 0) {
+          delete child;
+    }
+    // Add untracked file content.
+    if (patch.isUntracked()) {
+      if (!QFileInfo(path).isDir())
+        mHunkLayout->addWidget(addHunk(mDiff, patch, -1, lfs, submodule));
+      return;
+    }
+
+    // Generate a diff between the head tree and index.
+    QSet<int> stagedHunks;
+    if (staged.isValid()) {
+      for (int i = 0; i < staged.count(); ++i)
+        stagedHunks.insert(staged.lineNumber(i, 0, git::Diff::OldFile));
+    }
+
+    // Add diff hunks.
+    int hunkCount = patch.count();
+    for (int hidx = 0; hidx < hunkCount; ++hidx) {
+      HunkWidget *hunk = addHunk(mDiff, patch, hidx, lfs, submodule);
+      int startLine = patch.lineNumber(hidx, 0, git::Diff::OldFile);
+      hunk->header()->check()->setChecked(stagedHunks.contains(startLine));
+      mHunkLayout->addWidget(hunk);
+    }
   }
 
   Header *header() const { return mHeader; }
@@ -2039,14 +2060,15 @@ signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
 
 private:
-  DiffView *mView;
+  DiffView *mView{nullptr};
 
   git::Diff mDiff;
   git::Patch mPatch;
 
-  Header *mHeader;
+  Header *mHeader{nullptr};
   QList<QWidget *> mImages;
   QList<HunkWidget *> mHunks;
+  QVBoxLayout* mHunkLayout{nullptr};
 };
 
 } // anon. namespace

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1597,7 +1597,7 @@ public:
       bool lfs,
       bool submodule,
       QWidget *parent = nullptr)
-      : QFrame(parent), mDiff(diff), mPatch(patch)
+      : QFrame(parent), mDiff(diff), mPatch(patch), mSubmodule(submodule)
     {
       setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
@@ -1605,17 +1605,15 @@ public:
       mCheck = new QCheckBox(this);
       mCheck->setVisible(diff.isStatusDiff());
 
-      char status = git::Diff::statusChar(patch.status());
-      Badge *badge = new Badge({Badge::Label(QChar(status))}, this);
+      mStatusBadge = new Badge({}, this);
 
-      LineStats *stats = nullptr;
-      git::Patch::LineStats lineStats = patch.lineStats();
-      if (lineStats.additions > 0 || lineStats.deletions > 0)
-        stats = new LineStats(lineStats, this);
+      git::Patch::LineStats lineStats;
+      lineStats.additions = 0;
+      lineStats.deletions = 0;
+      mStats = new LineStats(lineStats, this);
+      mStats->setVisible(false);
 
-      FileLabel *label = new FileLabel(name, submodule, this);
-      if (patch.status() == GIT_DELTA_RENAMED)
-        label->setOldName(patch.name(git::Diff::OldFile));
+      mFileLabel = new FileLabel(name, submodule, this);
 
       QHBoxLayout *buttons = new QHBoxLayout;
       buttons->setContentsMargins(0,0,0,0);
@@ -1625,10 +1623,9 @@ public:
       layout->setContentsMargins(4,4,4,4);
       layout->addWidget(mCheck);
       layout->addSpacing(4);
-      layout->addWidget(badge);
-      if (stats)
-        layout->addWidget(stats);
-      layout->addWidget(label, 1);
+      layout->addWidget(mStatusBadge);
+      layout->addWidget(mStats);
+      layout->addWidget(mFileLabel, 1);
       layout->addStretch();
       layout->addLayout(buttons);
 
@@ -1668,56 +1665,54 @@ public:
       buttons->addWidget(mEdit);
 
       // Add discard button.
-      if (diff.isStatusDiff() && !submodule && !patch.isConflicted()) {
-        DiscardButton *discard = new DiscardButton(this);
-        discard->setToolTip(FileWidget::tr("Discard File"));
-        buttons->addWidget(discard);
+      mDiscardButton = new DiscardButton(this);
+      mDiscardButton->setVisible(false);
+      mDiscardButton->setToolTip(FileWidget::tr("Discard File"));
+      buttons->addWidget(mDiscardButton);
+      connect(mDiscardButton, &QToolButton::clicked, [this] {
+        QString name = mPatch.name();
+        bool untracked = mPatch.isUntracked();
+        QString path = mPatch.repo().workdir().filePath(name);
+        QString arg = QFileInfo(path).isDir() ? FileWidget::tr("Directory") : FileWidget::tr("File");
+        QString title =
+          untracked ? FileWidget::tr("Remove %1?").arg(arg) : FileWidget::tr("Discard Changes?");
+        QString text = untracked ?
+          FileWidget::tr("Are you sure you want to remove '%1'?") :
+          FileWidget::tr("Are you sure you want to discard all changes in '%1'?");
+        QMessageBox *dialog = new QMessageBox(
+          QMessageBox::Warning, title, text.arg(name),
+          QMessageBox::Cancel, this);
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->setInformativeText(FileWidget::tr("This action cannot be undone."));
 
-        connect(discard, &QToolButton::clicked, [this] {
+        QString button =
+          untracked ? FileWidget::tr("Remove %1").arg(arg) : FileWidget::tr("Discard Changes");
+        QPushButton *discard =
+          dialog->addButton(button, QMessageBox::AcceptRole);
+        connect(discard, &QPushButton::clicked, [this, untracked] {
+          RepoView *view = RepoView::parentView(this);
+          git::Repository repo = mPatch.repo();
           QString name = mPatch.name();
-          bool untracked = mPatch.isUntracked();
-          QString path = mPatch.repo().workdir().filePath(name);
-          QString arg = QFileInfo(path).isDir() ? FileWidget::tr("Directory") : FileWidget::tr("File");
-          QString title =
-            untracked ? FileWidget::tr("Remove %1?").arg(arg) : FileWidget::tr("Discard Changes?");
-          QString text = untracked ?
-            FileWidget::tr("Are you sure you want to remove '%1'?") :
-            FileWidget::tr("Are you sure you want to discard all changes in '%1'?");
-          QMessageBox *dialog = new QMessageBox(
-            QMessageBox::Warning, title, text.arg(name),
-            QMessageBox::Cancel, this);
-          dialog->setAttribute(Qt::WA_DeleteOnClose);
-          dialog->setInformativeText(FileWidget::tr("This action cannot be undone."));
-
-          QString button =
-            untracked ? FileWidget::tr("Remove %1").arg(arg) : FileWidget::tr("Discard Changes");
-          QPushButton *discard =
-            dialog->addButton(button, QMessageBox::AcceptRole);
-          connect(discard, &QPushButton::clicked, [this, untracked] {
-            RepoView *view = RepoView::parentView(this);
-            git::Repository repo = mPatch.repo();
-            QString name = mPatch.name();
-            int strategy = GIT_CHECKOUT_FORCE;
-            if (untracked) {
-              QDir dir = repo.workdir();
-              if (QFileInfo(dir.filePath(name)).isDir()) {
-                if (dir.cd(name))
-                  dir.removeRecursively();
-              } else {
-                dir.remove(name);
-              }
-            } else if (!repo.checkout(git::Commit(), nullptr, {name}, strategy)) {
-              LogEntry *parent = view->addLogEntry(mPatch.name(), FileWidget::tr("Discard"));
-              view->error(parent, FileWidget::tr("discard"), mPatch.name());
+          int strategy = GIT_CHECKOUT_FORCE;
+          if (untracked) {
+            QDir dir = repo.workdir();
+            if (QFileInfo(dir.filePath(name)).isDir()) {
+              if (dir.cd(name))
+                dir.removeRecursively();
+            } else {
+              dir.remove(name);
             }
+          } else if (!repo.checkout(git::Commit(), nullptr, {name}, strategy)) {
+            LogEntry *parent = view->addLogEntry(mPatch.name(), FileWidget::tr("Discard"));
+            view->error(parent, FileWidget::tr("discard"), mPatch.name());
+          }
 
-            // FIXME: Work dir changed?
-            view->refresh();
-          });
-
-          dialog->open();
+          // FIXME: Work dir changed?
+          view->refresh();
         });
-      }
+
+        dialog->open();
+      });
 
       mDisclosureButton = new DisclosureButton(this);
       mDisclosureButton->setToolTip(
@@ -1727,6 +1722,8 @@ public:
           mDisclosureButton->isChecked() ? FileWidget::tr("Collapse File") : FileWidget::tr("Expand File"));
       });
       buttons->addWidget(mDisclosureButton);
+
+      updatePatch(patch);
 
       if (!diff.isStatusDiff())
         return;
@@ -1749,6 +1746,23 @@ public:
       updateCheckState();
     }
 
+    void updatePatch(const git::Patch &patch) {
+        char status = git::Diff::statusChar(patch.status());
+        mStatusBadge->setLabels({Badge::Label(QChar(status))});
+
+        git::Patch::LineStats lineStats = patch.lineStats();
+        mStats->setStats(lineStats);
+        mStats->setVisible(lineStats.additions > 0 || lineStats.deletions > 0);
+
+        mFileLabel->setName(patch.name());
+        if (patch.status() == GIT_DELTA_RENAMED)
+          mFileLabel->setOldName(patch.name(git::Diff::OldFile));
+
+        mEdit->updatePatch(patch, -1);
+
+        mDiscardButton->setVisible(mDiff.isStatusDiff() && !mSubmodule && !patch.isConflicted());
+
+    }
     QCheckBox *check() const { return mCheck; }
 
     DisclosureButton *disclosureButton() const { return mDisclosureButton; }
@@ -1801,11 +1815,16 @@ public:
 
     git::Diff mDiff;
     git::Patch mPatch;
+    bool mSubmodule;
 
-    QCheckBox *mCheck;
+    QCheckBox *mCheck{nullptr};
     QToolButton *mLfsButton = nullptr;
-    EditButton *mEdit;
-    DisclosureButton *mDisclosureButton;
+    EditButton *mEdit{nullptr};
+    DiscardButton *mDiscardButton{nullptr};
+    DisclosureButton *mDisclosureButton{nullptr};
+    LineStats* mStats{nullptr};
+    Badge *mStatusBadge{nullptr};
+    FileLabel *mFileLabel{nullptr};
   };
 
   FileWidget(

--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -1746,6 +1746,11 @@ public:
       updateCheckState();
     }
 
+    /*!
+     * \brief Filewidget::Header: updatePatch
+     * when the patch is changed, update the edit button and update the status labels (mStats and mStatusBadge)
+     * \param patch
+     */
     void updatePatch(const git::Patch &patch) {
         char status = git::Diff::statusChar(patch.status());
         mStatusBadge->setLabels({Badge::Label(QChar(status))});
@@ -1942,6 +1947,12 @@ public:
     return (mHunks.isEmpty() && mImages.isEmpty());
   }
 
+  /*!
+   * \brief updatePatch
+   * update patch without recreating the FileWidget object.
+   * \param patch
+   * \param staged
+   */
   void updatePatch(const git::Patch &patch, const git::Patch &staged) {
     mHeader->updatePatch(patch);
 


### PR DESCRIPTION
So it is possible to update the patch without recreating all the graphical objects which takes longer.
Dependencies: #517 #518 