### PR TITLE
Add line length check to commit message editor

### DIFF
--- a/conf/themes/Dark.lua
+++ b/conf/themes/Dark.lua
@@ -126,7 +126,7 @@ theme['checkbox']  = {
 theme['commiteditor'] = {
   spellerror       = '#BC0009', -- spell check error
   spellignore      = '#E1E5F2', -- spell check ignored word(s)
-  lengthwarning    = '#464614'  -- line length limit warning (background)
+  lengthwarning    = '#565614'  -- line length limit warning (background)
 }
 
 -- diff view colors

--- a/pack/CMakeLists.txt
+++ b/pack/CMakeLists.txt
@@ -30,10 +30,10 @@ else()
 endif()
 
 foreach(QT_PLUGIN ${QT_PLUGINS})
-  get_target_property(PLUGIN Qt5::${QT_PLUGIN} LOCATION_${CMAKE_BUILD_TYPE})
-  get_filename_component(FILE_NAME ${PLUGIN} NAME)
-  get_filename_component(DIR ${PLUGIN} DIRECTORY)
-  get_filename_component(DIR_NAME ${DIR} NAME)
+  #get_target_property(PLUGIN Qt5::${QT_PLUGIN} LOCATION_${CMAKE_BUILD_TYPE})
+  #get_filename_component(FILE_NAME ${PLUGIN} NAME)
+  #get_filename_component(DIR ${PLUGIN} DIRECTORY)
+  #get_filename_component(DIR_NAME ${DIR} NAME)
   set(PLUGIN_PATH Plugins/${DIR_NAME}/${FILE_NAME})
 
   install(FILES ${PLUGIN}

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -531,13 +531,13 @@ QColor Theme::commitEditor(CommitEditor color)
     switch (color) {
       case CommitEditor::SpellError:    return "#BC0009";
       case CommitEditor::SpellIgnore:   return "#E1E5F2";
-      case CommitEditor::LengthWarning: return "#464614";
+      case CommitEditor::LengthWarning: return "#565614";
     }
   }
   switch (color) {
     case CommitEditor::SpellError:    return Qt::red;
     case CommitEditor::SpellIgnore:   return Qt::gray;
-    case CommitEditor::LengthWarning: return "#EFF0F1";
+    case CommitEditor::LengthWarning: return "#ECECBC";
   }
 }
 


### PR DESCRIPTION
The line length check settings are stored as repository setting.

Menu entries and settings:
![menu_settings](https://user-images.githubusercontent.com/67198194/99670473-e1ec5e00-2a70-11eb-8b0a-245c2cf32e61.png)
Subject Line Length Check: limit for the subject line (first line)
Insert Blank Line between Subject and Body: leave the second line empty
Body Text Length Check: limit for the message text

Changing the limits:
![menu_tooltip](https://user-images.githubusercontent.com/67198194/99670707-3abbf680-2a71-11eb-9aa6-46b175aa6692.png)
Mouse wheel: increment /decrement the selected limit
Numeric keys: enter a new limit, value range is 0 .. 200
Space key: enable/disable selected check (same as mouse click, but the menu remains open)

Subject line example:
![subject_violation](https://user-images.githubusercontent.com/67198194/99670889-88386380-2a71-11eb-9635-0cadaa42f521.png)
Context menu option 'Truncate Line' applied:
![subject_truncated](https://user-images.githubusercontent.com/67198194/99670973-a605c880-2a71-11eb-9d74-c0b4e04640c5.png)

Message text example:
![body_violation](https://user-images.githubusercontent.com/67198194/99671040-c3d32d80-2a71-11eb-8666-9e81d89570a7.png)
Context menu option 'Insert All Wordwraps' applied:
![body_wordwrap](https://user-images.githubusercontent.com/67198194/99671095-d77e9400-2a71-11eb-9b70-8b05869fbb43.png)

Undo / Redo is available.

Solves #478 