### PR TITLE
Fix "Push Tag to" and "Delete Tag" crashes

### DIFF
--- a/src/dialogs/DeleteTagDialog.cpp
+++ b/src/dialogs/DeleteTagDialog.cpp
@@ -41,7 +41,7 @@ DeleteTagDialog::DeleteTagDialog(
     RepoView *view = RepoView::parentView(this);
     QString name = tag.name();
 
-    if (checkBox()->isChecked()) {
+    if (remote.isValid() && checkBox()->isChecked()) {
       git::Repository repo = view->repo();
 
       QString remoteName = remote.name();

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -525,10 +525,12 @@ void ReferenceView::contextMenuEvent(QContextMenuEvent *event)
 
   if (ref.isTag()) {
     git::Remote remote = ref.repo().defaultRemote();
-    menu.addAction(tr("Push Tag to %1").arg(remote.name()),
-      [this, ref, view, remote] {
-        view->push(remote, ref);
-      });
+    if (remote.isValid()) {
+      menu.addAction(tr("Push Tag to %1").arg(remote.name()),
+        [this, ref, view, remote] {
+          view->push(remote, ref);
+        });
+    }
   }
 
   if (ref.isRemoteBranch()) {


### PR DESCRIPTION
1. Disable "Push Tag to" context menu when there are no appropriate remotes.
2. Fix "Delete Tag" dialog crash when no upstreams are configured.