### PR TITLE
Fix branch rename behavior

### DIFF
--- a/src/dialogs/BranchTableModel.cpp
+++ b/src/dialogs/BranchTableModel.cpp
@@ -91,8 +91,26 @@ QVariant BranchTableModel::headerData(
 
 Qt::ItemFlags BranchTableModel::flags(const QModelIndex &index) const
 {
-  return QAbstractTableModel::flags(index) |
-    ((index.column() == Rebase) ?  Qt::ItemIsUserCheckable : Qt::ItemIsEditable);
+  Qt::ItemFlags flags = QAbstractTableModel::flags(index);
+
+  switch (index.column()) {
+    case Name: {
+      git::Branch branch = branches().at(index.row());
+      if (!branch.isHead())
+        flags |= Qt::ItemIsEditable;
+      break;
+    }
+
+    case Upstream:
+      flags |= Qt::ItemIsEditable;
+      break;
+
+    case Rebase:
+      flags |= Qt::ItemIsUserCheckable;
+      break;
+  }
+
+  return flags;
 }
 
 bool BranchTableModel::setData(

--- a/src/git/Branch.cpp
+++ b/src/git/Branch.cpp
@@ -118,7 +118,10 @@ Branch Branch::rename(const QString &name)
 
   // Invalidate this branch.
   d.clear();
-  return Branch(ref);
+
+  Branch branch(ref);
+  emit branch.repo().notifier()->referenceUpdated(branch);
+  return branch;
 }
 
 void Branch::remove(bool force)


### PR DESCRIPTION
1. Keep repository view up-to-date after the branch was renamed.
2. Prevent HEAD branch from being renamed (to match with context menu's behavior).