### PR TITLE
Fix "Copy File Name" bug

### DIFF
--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -272,7 +272,7 @@ FileContextMenu::FileContextMenu(
     QString abs = QDir::toNativeSeparators(dir.filePath(file));
     QString name = QFileInfo(file).fileName();
     QMenu *copy = addMenu(tr("Copy File Name"));
-    if (name != file) {
+    if (!name.isEmpty() && name != file) {
       copy->addAction(name, [name] {
         QApplication::clipboard()->setText(name);
       });


### PR DESCRIPTION
A blank filename appears when you right-click an unstaged directory.
![unstaged_directory](https://user-images.githubusercontent.com/32811754/100386472-ce408900-3068-11eb-9fa0-ea157db80a38.png)
