### PR TITLE
Allow invalid patch data

### DIFF
--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -2282,7 +2282,8 @@ void DiffView::fetchMore()
   RepoView *view = RepoView::parentView(this);
   for (int pidx = init; pidx < patchCount && pidx - init < 8; ++pidx) {
     git::Patch patch = mDiff.patch(pidx);
-    if (!patch.isValid()) {
+    if (!patch.isValid() &&
+        (mDiff.status(pidx) != GIT_DELTA_UNMODIFIED)) {
       // This diff is stale. Refresh the view.
       QTimer::singleShot(0, view, &RepoView::refresh);
       return;
@@ -2294,7 +2295,7 @@ void DiffView::fetchMore()
 
     mFiles.append(file);
 
-    if (file->isEmpty()) {
+    if (file->isEmpty() || !patch.isValid()) {
       DisclosureButton *button = file->header()->disclosureButton();
       button->setChecked(false);
       button->setEnabled(false);


### PR DESCRIPTION
Avoid segmentation faults and endless view refresh cycles when diff.patch() returns an invalid patch (data = nullptr).
Access functions are protected by calling `isValid()` prior to patch data access.

History:
I do not know how to reproduce, but the translation files of my GitAhead repository got corrupted.
![git_status](https://user-images.githubusercontent.com/67198194/100443867-c73a6a80-30aa-11eb-9669-3c5de7d59552.png)
`git status` marked the l10/* translation files as modified.

![git_diff](https://user-images.githubusercontent.com/67198194/100443938-e76a2980-30aa-11eb-8bbd-787d6dbc604b.png)
`git diff` showed me a warning about the l10/* files line ending.

After applying this patch, I was able to solve the problem using GitAhead:
![i10_patch_invalid](https://user-images.githubusercontent.com/67198194/100444070-226c5d00-30ab-11eb-9954-74af096d6451.png)
In the `FileList` the files are marked as staged (`git status` did not show that) - unstaging them does not work.
The file status Badge is empty, because diff.status() = GIT_DELTA_UNMODIFIED (`git status` did show 'M')
By discarding the changes (discard button) the git database got fixed.

Remark: the l10/* files always had the proper line ending (for Windows in this case).