### PR TITLE
Menu bar fixes

### DIFF
--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -68,6 +68,8 @@ bool MenuBar::sDebugMenuVisible = false;
 MenuBar::MenuBar(QWidget *parent)
   : QMenuBar(parent)
 {
+  setContextMenuPolicy(Qt::PreventContextMenu);
+
   // File
   QMenu *file = addMenu(tr("File"));
 

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -856,7 +856,7 @@ void MenuBar::updateRepository()
 
   bool lfs = view && view->repo().lfsIsInitialized();
   mLfsUnlock->setEnabled(lfs);
-  mLfsInitialize->setEnabled(!lfs);
+  mLfsInitialize->setEnabled(view && !lfs);
 }
 
 void MenuBar::updateRemote()


### PR DESCRIPTION
1. Gray-out Git LFS "initialize" menu when there are no open repositories.

2. Disable the right-click menu which can be used to hide the tool bar.
This may have been useful, but I think it wasn't the intended one.