### PR TITLE
Disable unborn HEAD stashing

### DIFF
--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -953,7 +953,7 @@ void MenuBar::updateStash()
   RepoView *view = win ? win->currentView() : nullptr;
   bool stash = view && view->repo().stashRef().isValid();
   mShowStashes->setEnabled(stash);
-  mStash->setEnabled(view && view->isWorkingDirectoryDirty());
+  mStash->setEnabled(view && view->canStash());
   mStashPop->setEnabled(stash);
 }
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1287,13 +1287,15 @@ void RepoView::fastForward(
     QUrl url("action:fast-forward");
     url.setQuery(query);
 
-    // Add stash hint.
-    QString stash =
-      tr("You may be able to reconcile your changes with the conflicting "
-         "files by <a href='action:stash'>stashing</a> before you "
-         "<a href='%1'>fast-forward</a>. Then "
-         "<a href='action:unstash'>unstash</a> to restore your changes.");
-    err->addEntry(LogEntry::Hint, stash.arg(url.toString()));
+    // Add stash hint if available.
+    if (canStash()) {
+      QString stash =
+        tr("You may be able to reconcile your changes with the conflicting "
+           "files by <a href='action:stash'>stashing</a> before you "
+           "<a href='%1'>fast-forward</a>. Then "
+           "<a href='action:unstash'>unstash</a> to restore your changes.");
+      err->addEntry(LogEntry::Hint, stash.arg(url.toString()));
+    }
 
     query.addQueryItem("no-ff", "true");
     url.setPath("merge");
@@ -1330,7 +1332,7 @@ void RepoView::merge(
     // Add stash hint if the failure was because of uncommitted changes.
     QString msg = git::Repository::lastError();
     int kind = git::Repository::lastErrorKind();
-    if (kind == GIT_ERROR_MERGE && msg.contains("overwritten by merge")) {
+    if (kind == GIT_ERROR_MERGE && msg.contains("overwritten by merge") && canStash()) {
       QString text =
         tr("You may be able to rebase by <a href='action:stash'>stashing</a> "
            "before trying to <a href='action:merge'>merge</a>. Then "
@@ -1460,7 +1462,7 @@ void RepoView::rebase(
     // Add stash hint if the failure was because of uncommitted changes.
     QString msg = git::Repository::lastError();
     int kind = git::Repository::lastErrorKind();
-    if (kind == GIT_ERROR_REBASE && msg.contains("changes exist")) {
+    if (kind == GIT_ERROR_REBASE && msg.contains("changes exist") && canStash()) {
       QString text =
         tr("You may be able to rebase by <a href='action:stash'>stashing</a> "
            "before trying to <a href='action:rebase'>rebase</a>. Then "
@@ -1523,7 +1525,7 @@ void RepoView::squash(
     // Add stash hint if the failure was because of uncommitted changes.
     QString msg = git::Repository::lastError();
     int kind = git::Repository::lastErrorKind();
-    if (kind == GIT_ERROR_MERGE && msg.contains("overwritten by merge")) {
+    if (kind == GIT_ERROR_MERGE && msg.contains("overwritten by merge") && canStash()) {
       QString text =
         tr("You may be able to rebase by <a href='action:stash'>stashing</a> "
            "before trying to <a href='action:merge'>merge</a>. Then "
@@ -2045,13 +2047,15 @@ void RepoView::checkout(
       if (detach)
         query.addQueryItem("detach", "true");
 
-      // Add stash hint.
-      QString text =
-        tr("You may be able to reconcile your changes with the conflicting "
-           "files by <a href='action:stash'>stashing</a> before you "
-           "<a href='action:checkout?%1'>checkout '%2'</a>. Then "
-           "<a href='action:unstash'>unstash</a> to restore your changes.");
-      err->addEntry(LogEntry::Hint, text.arg(query.toString(), ref.name()));
+      // Add stash hint if available.
+      if (canStash()) {
+        QString text =
+          tr("You may be able to reconcile your changes with the conflicting "
+             "files by <a href='action:stash'>stashing</a> before you "
+             "<a href='action:checkout?%1'>checkout '%2'</a>. Then "
+             "<a href='action:unstash'>unstash</a> to restore your changes.");
+        err->addEntry(LogEntry::Hint, text.arg(query.toString(), ref.name()));
+      }
     }
 
     return;
@@ -2105,6 +2109,9 @@ void RepoView::promptToDeleteBranch(const git::Reference &ref)
 
 void RepoView::promptToStash()
 {
+  if (!canStash())
+    return;
+
   // Prompt to edit stash commit message.
   if (!Settings::instance()->prompt(Settings::PromptStash)) {
     stash();
@@ -2180,6 +2187,11 @@ void RepoView::popStash(int index)
   }
 
   refresh();
+}
+
+bool RepoView::canStash() const
+{
+  return !mRepo.isHeadUnborn() && isWorkingDirectoryDirty();
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit)

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -263,6 +263,7 @@ public:
   void applyStash(int index = 0);
   void dropStash(int index = 0);
   void popStash(int index = 0);
+  bool canStash() const;
 
   // tag
   void promptToAddTag(const git::Commit &commit);

--- a/src/ui/ToolBar.cpp
+++ b/src/ui/ToolBar.cpp
@@ -992,7 +992,7 @@ void ToolBar::updateHistory()
 void ToolBar::updateStash()
 {
   RepoView *view = currentView();
-  mStashButton->setEnabled(view && view->isWorkingDirectoryDirty());
+  mStashButton->setEnabled(view && view->canStash());
   mStashPopButton->setEnabled(view && view->repo().stashRef().isValid());
 }
 


### PR DESCRIPTION
This issue can be reproduced by taking the following steps:
1. Initialize a new repository.
2. Stage some additions (but do not commit).
3. Refresh view (F5).
4. Stash menu is now activated (which leads to crash).

libgit2 can't stash the unborn HEAD either, so:
- Disable stash menu/button/action for the unborn HEAD.
- Don't suggest to use stash if unavailable.