### PR TITLE
Add commit infos to 'Ours' and 'Theirs' button

### DIFF
--- a/src/ui/DiffView.cpp
+++ b/src/ui/DiffView.cpp
@@ -639,6 +639,8 @@ void lookupCommitInfos(
           branch = ref.name();
           break;
         }
+        else if (ref.isTag())
+          branch = ref.name();
       }
 
       // Set tooltip.
@@ -662,7 +664,7 @@ void lookupCommitInfos(
 
   // Set button text and tooltip.
   if (!branch.isEmpty())
-    button->setText(button->text() + "( " + branch + ")");
+    button->setText(button->text() + " (" + branch + ")");
   if (!tooltip.isEmpty())
     button->setToolTip(tooltip);
 }


### PR DESCRIPTION
An additional tool tip displays commit id, author and date.
The 'ours' and 'theirs' commits background is drawn with the related color.

![background_tooltip](https://user-images.githubusercontent.com/67198194/102803859-3741c500-43b9-11eb-844e-5590cc0de3db.png)

Solves #163 