### PR TITLE
Import/Export git .diff files

### DIFF
--- a/src/dialogs/CMakeLists.txt
+++ b/src/dialogs/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(dialogs
   ConfigDialog.cpp
   DeleteBranchDialog.cpp
   DeleteTagDialog.cpp
+  DiffFileDialog.cpp
   DiffPanel.cpp
   ExternalToolsDialog.cpp
   ExternalToolsModel.cpp

--- a/src/dialogs/DiffFileDialog.cpp
+++ b/src/dialogs/DiffFileDialog.cpp
@@ -1,0 +1,57 @@
+//
+//          Copyright (c) 2021, Scientific Toolworks, Inc.
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+
+#include "DiffFileDialog.h"
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QSettings>
+#include <QString>
+
+namespace {
+
+const QString kLastDirKey = "diff/lastdir";
+
+} // anon. namespace
+
+QString DiffFileDialog::getApplyFileName(QWidget *parent)
+{
+  QString path = QFileDialog::getOpenFileName(parent, tr("Apply Diff File"), lastDir(), filter());
+  saveLastDir(path);
+  return path;
+}
+
+QString DiffFileDialog::getSaveFileName(QWidget *parent)
+{
+  QString path = QFileDialog::getSaveFileName(parent, tr("Save Diff File"), lastDir(), filter());
+  saveLastDir(path);
+  return path;
+}
+
+QString DiffFileDialog::filter()
+{
+  return tr("Git Diff (*.diff *.patch);;All files (*)");
+}
+
+QString DiffFileDialog::lastDir()
+{
+  QString dir = QSettings().value(kLastDirKey).toString();
+
+  if (dir.isEmpty() || !QDir(dir).exists())
+    dir = QDir::homePath();
+
+  return dir;
+}
+
+void DiffFileDialog::saveLastDir(const QString &path)
+{
+  if (path.isEmpty())
+    return;
+
+  QString dir = QFileInfo(path).absolutePath();
+  QSettings().setValue(kLastDirKey, dir);
+}

--- a/src/dialogs/DiffFileDialog.h
+++ b/src/dialogs/DiffFileDialog.h
@@ -1,0 +1,31 @@
+//
+//          Copyright (c) 2021, Scientific Toolworks, Inc.
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+
+#ifndef DIFFFILEDIALOG_H
+#define DIFFFILEDIALOG_H
+
+#include <QCoreApplication>
+
+class QString;
+class QWidget;
+
+class DiffFileDialog
+{
+  Q_DECLARE_TR_FUNCTIONS(DiffFileDialog)
+
+public:
+  static QString getApplyFileName(QWidget *parent = nullptr);
+  static QString getSaveFileName(QWidget *parent = nullptr);
+
+private:
+  static QString filter();
+
+  static QString lastDir();
+  static void saveLastDir(const QString &path);
+};
+
+#endif

--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -169,12 +169,30 @@ void Diff::setAllStaged(bool staged, bool yieldFocus)
   index().setStaged(paths, staged);
 }
 
+QByteArray Diff::toBuffer(git_diff_format_t format) const
+{
+  git_buf buf = GIT_BUF_INIT_CONST(nullptr, 0);
+  if (git_diff_to_buf(&buf, d->diff, format))
+    return QByteArray();
+
+  QByteArray text(buf.ptr, buf.size);
+  git_buf_dispose(&buf);
+  return text;
+}
+
 char Diff::statusChar(git_delta_t status)
 {
   if (status == GIT_DELTA_CONFLICTED)
     return '!';
 
   return git_diff_status_char(status);
+}
+
+Diff Diff::fromBuffer(const QByteArray &text)
+{
+  git_diff *diff = nullptr;
+  git_diff_from_buffer(&diff, text.constData(), text.size());
+  return Diff(diff);
 }
 
 } // namespace git

--- a/src/git/Diff.h
+++ b/src/git/Diff.h
@@ -79,7 +79,11 @@ public:
 
   void setAllStaged(bool staged, bool yieldFocus = true);
 
+  QByteArray toBuffer(git_diff_format_t format = GIT_DIFF_FORMAT_PATCH) const;
+
   static char statusChar(git_delta_t status);
+
+  static Diff fromBuffer(const QByteArray &text);
 
 private:
   struct Data

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -334,6 +334,15 @@ Diff Repository::diffIndexToWorkdir(
   return Diff(diff);
 }
 
+bool Repository::applyDiff(const Diff &diff, git_apply_location_t location)
+{
+  if (git_apply(d->repo, diff, location, nullptr))
+    return false;
+
+  emit d->notifier->referenceUpdated(head());
+  return true;
+}
+
 Reference Repository::head() const
 {
   git_reference *ref = nullptr;

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -16,6 +16,7 @@
 #include "Commit.h"
 #include "Diff.h"
 #include "Index.h"
+#include "git2/apply.h"
 #include "git2/checkout.h"
 #include "git2/errors.h"
 #include "git2/revwalk.h"
@@ -111,6 +112,9 @@ public:
     const Index &index = Index(),
     Diff::Callbacks *callbacks = nullptr,
     bool ignoreWhitespace = false) const;
+  bool applyDiff(
+    const Diff &diff,
+    git_apply_location_t location = GIT_APPLY_LOCATION_WORKDIR);
 
   // refs
   QList<Reference> refs() const;

--- a/src/ui/CommitList.h
+++ b/src/ui/CommitList.h
@@ -87,6 +87,8 @@ private:
   bool isDecoration(const QModelIndex &index, const QPoint &pos);
   bool isStar(const QModelIndex &index, const QPoint &pos);
 
+  void saveDiff(const QString &path) const;
+
   QString mFile;
   QModelIndex mStar;
   QModelIndex mCancel;

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -365,6 +365,13 @@ MenuBar::MenuBar(QWidget *parent)
 
   repository->addSeparator();
 
+  mApplyDiff = repository->addAction(tr("Apply Diff..."));
+  connect(mApplyDiff, &QAction::triggered, [this] {
+    view()->promptToApplyDiff();
+  });
+
+  repository->addSeparator();
+
   QMenu *lfs = repository->addMenu(tr("Git LFS"));
   mLfsUnlock = lfs->addAction(tr("Remove all locks"));
   connect(mLfsUnlock, &QAction::triggered, [this] {
@@ -853,6 +860,7 @@ void MenuBar::updateRepository()
   mStageAll->setEnabled(view && view->isStageEnabled());
   mUnstageAll->setEnabled(view && view->isUnstageEnabled());
   mAmendCommit->setEnabled(view);
+  mApplyDiff->setEnabled(view);
 
   bool lfs = view && view->repo().lfsIsInitialized();
   mLfsUnlock->setEnabled(lfs);

--- a/src/ui/MenuBar.h
+++ b/src/ui/MenuBar.h
@@ -73,6 +73,7 @@ private:
   QAction *mUnstageAll;
   QAction *mCommit;
   QAction *mAmendCommit;
+  QAction *mApplyDiff;
   QAction *mLfsUnlock;
   QAction *mLfsInitialize;
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -214,6 +214,9 @@ public:
   // cherry-pick
   void cherryPick(const git::Commit &commit);
 
+  // diff
+  void promptToApplyDiff();
+
   // push
   void promptToForcePush(
     const git::Remote &remote = git::Remote(),
@@ -347,6 +350,8 @@ private:
     bool init = false);
 
   bool checkForConflicts(LogEntry *parent, const QString &action);
+
+  void applyDiff(const QString &path);
 
   git::Repository mRepo;
 


### PR DESCRIPTION
This feature might be useful in these cases:
- You're working on a project that does not use Git or accept Pull Requests.
- You want to share a small amount of changeset within your group, without setting up your remote repository.

1. A diff file can be exported by right-clicking commit(s):
![SaveDiffAs](https://user-images.githubusercontent.com/32811754/112119039-56423400-8c00-11eb-8f3b-76a9fe754687.png)

2. Previously exported diff file can be imported by choosing `Repository -> Apply Diff...` menu:
![ApplyDiff](https://user-images.githubusercontent.com/32811754/112119155-740f9900-8c00-11eb-9777-21869683af75.png)

3. File handling errors (e.g. permissions) will be reported on the log window to avoid unexpected data loss:
![Logs](https://user-images.githubusercontent.com/32811754/112119185-7bcf3d80-8c00-11eb-8f0b-6ff781afac1d.png)