### PR TITLE
Fix SpellChecker crashes

### DIFF
--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -513,7 +513,7 @@ private:
     cursor.select(QTextCursor::WordUnderCursor);
     QString word = cursor.selectedText();
     if (!mSpellChecker || word.isEmpty()) {
-      contextMenuEvent(event);
+      QTextEdit::contextMenuEvent(event);
       return;
     }
 

--- a/src/ui/SpellChecker.h
+++ b/src/ui/SpellChecker.h
@@ -23,7 +23,7 @@ public:
   bool isValid(void) const { return mValid; }
 
 private:
-  Hunspell *mHunspell;
+  Hunspell *mHunspell = nullptr;
 
   QTextCodec *mCodec;
   QString mUserDictionary;


### PR DESCRIPTION
Fixed two issues:

1. If no spell check dictionaries are installed, SpellChecker instance may be destructed immediately, without initializing the mHunspell pointer.
This will cause a crash in its destructor as it attempts to delete the invalid pointer.
2. If the spell check was disabled, it will cause another crash in contextMenuEvent() because of infinite recursions.