### PR TITLE
Change 'Reset Local Branch' behavior on remote branch checkout

### DIFF
--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1963,7 +1963,16 @@ void RepoView::checkout(
     QPushButton *resetButton =
       dialog->addButton(tr("Reset Local Branch"), QMessageBox::AcceptRole);
     connect(resetButton, &QPushButton::clicked, [this, ref, local] {
-      createBranch(local, ref.target(), ref, true, true);
+      git::Branch head = mRepo.head();
+      if (head.isValid() && head.name() == local) {
+        // The local branch is currently checked out and cannot be replaced.
+        // We'll just reset it instead.
+        if (reset(ref.target(), GIT_RESET_HARD))
+          head.setUpstream(ref);
+      } else {
+        // Replace local branch.
+        createBranch(local, ref.target(), ref, true, true);
+      }
     });
   } else {
     dialog->setText(
@@ -2238,7 +2247,7 @@ void RepoView::promptToReset(
   dialog->open();
 }
 
-void RepoView::reset(
+bool RepoView::reset(
   const git::Commit &commit,
   git_reset_t type,
   const git::Commit &commitToAmend)
@@ -2250,8 +2259,12 @@ void RepoView::reset(
   QString text = tr("%1 to %2").arg(head.name(), commit.link());
   LogEntry *entry = addLogEntry(text, title);
 
-  if (!commit.reset(type))
+  if (!commit.reset(type)) {
     error(entry, commitToAmend ? tr("amend") : tr("reset"), head.name());
+    return false;
+  }
+
+  return true;
 }
 
 void RepoView::updateSubmodules(

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -270,7 +270,7 @@ public:
     const git::Commit &commit,
     git_reset_t type,
     const git::Commit &commitToAmend = git::Commit());
-  void reset(
+  bool reset(
     const git::Commit &commit,
     git_reset_t type,
     const git::Commit &commitToAmend = git::Commit());


### PR DESCRIPTION
When checking out a remote branch, you'll be prompted to whether `Reset Local Branch` or not.
This will not work for the local HEAD branch as libgit2 refuses to do that.

To workaround this, just literally reset the branch rather than replacing its own branch.
These two actions are slightly different (e.g. how the uncommitted changes are handled), but it can achieve the user's goal anyway.