### PR TITLE
Disable 'Git LFS Initialize' when not usable

### DIFF
--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -856,7 +856,7 @@ void MenuBar::updateRepository()
 
   bool lfs = view && view->repo().lfsIsInitialized();
   mLfsUnlock->setEnabled(lfs);
-  mLfsInitialize->setEnabled(!lfs);
+  mLfsInitialize->setEnabled(view && !lfs);
 }
 
 void MenuBar::updateRemote()


### PR DESCRIPTION
_Note: This PR is redo of #541 with more meaningful branch name._

Disable Git LFS "initialize" menu when there are no open repositories; this will cause a crash.