### PR TITLE
Fix some CI build and test issues

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -47,10 +47,10 @@ jobs:
           perl-version: '5.30'
       - name: Install Nmake
         if: matrix.env.name == 'win'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v1
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
       - name: Install NASM
         if: matrix.env.name == 'win'
-        uses: ilammy/setup-nasm@v1.0.0
+        uses: ilammy/setup-nasm@v1.2.0
       - name: Build OpenSSL (linux)
         if: matrix.env.name == 'linux'
         run: |
@@ -70,13 +70,13 @@ jobs:
           perl Configure VC-WIN64A
           nmake
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
         with:
           version: 1.9.0
           platform: ${{ matrix.env.ninja_platform }}
           destination: ninja
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.2.0
+        uses: jurplel/install-qt-action@v2.13.0
         timeout-minutes: 10
         with:
           version: 5.12.5

--- a/.github/workflows/build-stage.yml
+++ b/.github/workflows/build-stage.yml
@@ -48,10 +48,10 @@ jobs:
           perl-version: '5.30'
       - name: Install Nmake
         if: matrix.env.name == 'win'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v1
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
       - name: Install NASM
         if: matrix.env.name == 'win'
-        uses: ilammy/setup-nasm@v1.0.0
+        uses: ilammy/setup-nasm@v1.2.0
       - name: Build OpenSSL (linux)
         if: matrix.env.name == 'linux'
         run: |
@@ -71,13 +71,13 @@ jobs:
           perl Configure VC-WIN64A
           nmake
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
         with:
           version: 1.9.0
           platform: ${{ matrix.env.ninja_platform }}
           destination: ninja
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.2.0
+        uses: jurplel/install-qt-action@v2.13.0
         timeout-minutes: 10
         with:
           version: 5.12.5

--- a/test/Test.h
+++ b/test/Test.h
@@ -18,10 +18,14 @@
 #define TEST_MAIN(TestClass) \
 int main(int argc, char *argv[]) \
 { \
+  std::vector<const char*> new_argv(argv, argv + argc); \
+  new_argv.push_back("--theme Default"); \
+  argc += 2; \
+  argv = const_cast<char**>(new_argv.data()); \
   Application app(argc, argv); \
   TestClass test; \
   QTEST_SET_MAIN_SOURCE_PATH \
-  return QTest::qExec(&test, app.arguments()); \
+  return QTest::qExec(&test, {}); \
 }
 
 class RepoView;

--- a/test/branches_panel.cpp
+++ b/test/branches_panel.cpp
@@ -47,7 +47,7 @@ void TestBranchesPanel::initTestCase()
   RepoView *view = mWindow->currentView();
 
   git::Remote remote =
-    mRepo->addRemote("origin", "git@github.com:stinb/gitahead-test.git");
+    mRepo->addRemote("origin", "git://github.com/stinb/gitahead-test.git");
   fetch(view, remote);
 
   git::Branch upstream =


### PR DESCRIPTION
This change udpates some of the out of date github workflow action
helpers to the latest versions to get past deprecation errors.

As well, the '--theme Default' option is passed into the Application
during tests in order to bypass the theme selector dialog which most
tests are not expecting to be present and thus hang waiting for the main
dialog to be active.

Finally, the branches_panel test is updated to use the insecure
git//github.com/stinb/gitahead-test.git url instead of the default
git@github.com:stinb/gitahead-test.git url to avoid existing issues with
ssh, specifically when run in a container without ssh keys present (such
as in the github workflow actions environment).