### PR TITLE
Fix 'Fetch All' error if remote wasn't named 'origin'

### DIFF
--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -967,7 +967,7 @@ void RepoView::fetchAll()
     return;
 
   if (remotes.size() == 1) {
-    fetch();
+    fetch(remotes.at(0));
     return;
   }
 


### PR DESCRIPTION
`Fetch All` fails if there's only one remote, and it wasn't named 'origin':
![Remotes](https://user-images.githubusercontent.com/32811754/112125640-fef39200-8c06-11eb-88de-3fe76826b4e4.png)

This PR addresses that.