### PR TITLE
Suppress continuous credential dialog caused by auto-fetch

### DIFF
--- a/src/ui/RemoteCallbacks.cpp
+++ b/src/ui/RemoteCallbacks.cpp
@@ -311,6 +311,7 @@ void RemoteCallbacks::credentialsImpl(
   QString scheme = QUrl(url).scheme().toLower();
   bool https = (scheme == "http" || scheme == "https");
   dialog.setWindowTitle(https ? tr("HTTPS Credentials") : tr("SSH Passphrase"));
+  QObject::connect(&dialog, &QDialog::rejected, this, &RemoteCallbacks::credentialsCanceled);
 
   QLineEdit *usernameField = https ? new QLineEdit(username, &dialog) : nullptr;
   QLineEdit *passwordField = new QLineEdit(&dialog);

--- a/src/ui/RemoteCallbacks.h
+++ b/src/ui/RemoteCallbacks.h
@@ -68,6 +68,7 @@ public:
 
 signals:
   void referenceUpdated(const QString &name);
+  void credentialsCanceled();
 
   // These are implementation details.
   void queueCredentials(


### PR DESCRIPTION
Automatically disable auto-fetch if an user refused to provide the credential information.
(Related issues: #531, #584.)