### PR TITLE
Add support for 'git submodule add'

### DIFF
--- a/src/dialogs/CloneDialog.h
+++ b/src/dialogs/CloneDialog.h
@@ -10,6 +10,7 @@
 #ifndef CLONEDIALOG_H
 #define CLONEDIALOG_H
 
+#include "git/Repository.h"
 #include "host/Repository.h"
 #include <QFutureWatcher>
 #include <QWizard>
@@ -33,19 +34,26 @@ public:
   enum Kind
   {
     Init,
-    Clone
+    Clone,
+    Submodule
   };
 
   CloneDialog(
     Kind kind,
     QWidget *parent = nullptr,
-    Repository *repo = nullptr);
+    Repository *repo = nullptr,
+    const git::Repository &parentRepo = git::Repository());
 
   void accept() override;
 
   QString path() const;
   QString message() const;
   QString messageTitle() const;
+
+private:
+  QString windowTitle() const;
+
+  Kind mKind;
 };
 
 #endif

--- a/src/dialogs/ConfigDialog.cpp
+++ b/src/dialogs/ConfigDialog.cpp
@@ -11,6 +11,7 @@
 #include "AddRemoteDialog.h"
 #include "BranchDelegate.h"
 #include "BranchTableModel.h"
+#include "CloneDialog.h"
 #include "DeleteBranchDialog.h"
 #include "DiffPanel.h"
 #include "NewBranchDialog.h"
@@ -348,7 +349,7 @@ class SubmodulesPanel : public QWidget
 {
 public:
   SubmodulesPanel(RepoView *view, QWidget *parent = nullptr)
-    : QWidget(parent)
+    : QWidget(parent), mRepo(view->repo())
   {
     QTableView *table = new QTableView(this);
     table->verticalHeader()->setVisible(false);
@@ -357,7 +358,7 @@ public:
     table->setSelectionMode(QAbstractItemView::ExtendedSelection);
     table->setShowGrid(false);
 
-    table->setModel(new SubmoduleTableModel(view->repo(), this));
+    table->setModel(new SubmoduleTableModel(mRepo, this));
     table->setItemDelegate(new SubmoduleDelegate(table));
 
     // Set section resize mode after model is set.
@@ -372,14 +373,23 @@ public:
     });
 
     Footer *footer = new Footer(table);
-    footer->setPlusEnabled(false);
     footer->setMinusEnabled(false);
+    connect(footer, &Footer::plusClicked, this, &SubmodulesPanel::addSubmodule);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setSpacing(0);
     layout->addWidget(table);
     layout->addWidget(footer);
   }
+
+private:
+  void addSubmodule()
+  {
+    CloneDialog *dialog = new CloneDialog(CloneDialog::Submodule, this, nullptr, mRepo);
+    dialog->open();
+  }
+
+  git::Repository mRepo;
 };
 
 class SearchPanel : public QWidget

--- a/src/dialogs/SubmoduleTableModel.cpp
+++ b/src/dialogs/SubmoduleTableModel.cpp
@@ -17,7 +17,15 @@ SubmoduleTableModel::SubmoduleTableModel(
   const git::Repository &repo,
   QObject *parent)
   : QAbstractTableModel(parent), mSubmodules(repo.submodules()), mRepo(repo)
-{}
+{
+  git::RepositoryNotifier *notifier = repo.notifier();
+  connect(notifier, &git::RepositoryNotifier::submoduleAboutToBeAdded,
+          this, &SubmoduleTableModel::beginResetModel);
+  connect(notifier, &git::RepositoryNotifier::submoduleAdded, this, [this] {
+    mSubmodules = mRepo.submodules();
+    endResetModel();
+  });
+}
 
 int SubmoduleTableModel::rowCount(const QModelIndex &parent) const
 {

--- a/src/git/Remote.h
+++ b/src/git/Remote.h
@@ -26,6 +26,7 @@ namespace git {
 
 class Id;
 class Reference;
+class Submodule;
 
 class Remote
 {
@@ -213,6 +214,9 @@ public:
     const QString &url,
     const QString &path,
     bool bare = false);
+  static Result clone(
+    Callbacks *callbacks,
+    const Submodule &submodule);
 
   static QByteArray proxyUrl(const QString &url, git_proxy_t &type);
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -656,6 +656,25 @@ void Repository::setCommitStarred(const Id &commit, bool starred)
   file.commit();
 }
 
+Submodule Repository::addSubmoduleSetup(const QString &path, const QString &url)
+{
+  git_submodule *submodule = nullptr;
+  git_submodule_add_setup(&submodule, d->repo, url.toUtf8(), path.toUtf8(), 1);
+  return Submodule(submodule);
+}
+
+void Repository::addSubmoduleFinalize(const Submodule &submodule)
+{
+  Q_ASSERT(submodule.isValid());
+
+  emit d->notifier->submoduleAboutToBeAdded(submodule.name());
+
+  git_submodule_add_finalize(submodule);
+  invalidateSubmoduleCache();
+
+  emit d->notifier->submoduleAdded(submodule);
+}
+
 void Repository::invalidateSubmoduleCache()
 {
   git_repository_submodule_cache_clear(d->repo);

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -163,6 +163,8 @@ public:
   void setCommitStarred(const Id &commit, bool starred);
 
   // submodule
+  Submodule addSubmoduleSetup(const QString &path, const QString &url);
+  void addSubmoduleFinalize(const Submodule &submodule);
   void invalidateSubmoduleCache();
   QList<Submodule> submodules() const;
   Submodule lookupSubmodule(const QString &path) const;
@@ -312,6 +314,9 @@ signals:
   void remoteAdded(const Remote &remote);
   void remoteAboutToBeRemoved(const Remote &remote);
   void remoteRemoved(const QString &name);
+
+  void submoduleAboutToBeAdded(const QString &name);
+  void submoduleAdded(const Submodule &submodule);
 
   void stateChanged();
   void workdirChanged();

--- a/src/git/Submodule.h
+++ b/src/git/Submodule.h
@@ -58,6 +58,7 @@ private:
   QSharedPointer<git_submodule> d;
 
   friend class Index;
+  friend class Remote;
   friend class Repository;
 };
 


### PR DESCRIPTION
This PR adds an equivalent action of the `git submodule add` command.
It's built on the existing `Initialize Repository` or `Clone Repository` dialog, so the implementation is relatively simple.