### PR TITLE
Add 'Delete' menu action for remote branches

### DIFF
--- a/src/dialogs/DeleteBranchDialog.cpp
+++ b/src/dialogs/DeleteBranchDialog.cpp
@@ -9,84 +9,42 @@
 
 #include "DeleteBranchDialog.h"
 #include "git/Branch.h"
-#include "git/Config.h"
-#include "git/Remote.h"
-#include "log/LogEntry.h"
-#include "ui/RemoteCallbacks.h"
 #include "ui/RepoView.h"
 #include <QCheckBox>
-#include <QFutureWatcher>
 #include <QPushButton>
-#include <QtConcurrent>
-
-namespace {
-
-const QString kBranchMergeFmt = "branch.%1.merge";
-
-} // anon. namespace
 
 DeleteBranchDialog::DeleteBranchDialog(
   const git::Branch &branch,
   QWidget *parent)
   : QMessageBox(parent)
 {
-  QString text = tr("Are you sure you want to delete local branch '%1'?");
+  bool isLocal = branch.isLocalBranch();
+  QString text = tr("Are you sure you want to delete %1 branch '%2'?");
   setWindowTitle(tr("Delete Branch?"));
-  setText(text.arg(branch.name()));
+  setText(text.arg(isLocal ? tr("local") : tr("remote"), branch.name()));
   setStandardButtons(QMessageBox::Cancel);
 
-  git::Branch upstream = branch.upstream();
+  git::Branch upstream = isLocal ? branch.upstream() : git::Branch();
   if (upstream.isValid()) {
     QString text = tr("Also delete the upstream branch from its remote");
     setCheckBox(new QCheckBox(text, this));
   }
 
   QPushButton *remove = addButton(tr("Delete"), QMessageBox::AcceptRole);
-  connect (remove, &QPushButton::clicked, [this, branch, upstream] {
-    if (upstream.isValid() && checkBox()->isChecked()) {
-      RepoView *view = RepoView::parentView(this);
-      git::Repository repo = view->repo();
+  connect(remove, &QPushButton::clicked, [this, branch, isLocal, upstream] {
+    RepoView *view = RepoView::parentView(this);
+    if (isLocal)
+      git::Branch(branch).remove();
+    else
+      view->deleteRemoteBranch(branch);
 
-      QString name = upstream.name().section('/', 1);
-      QString key = kBranchMergeFmt.arg(branch.name());
-      QString upstreamName = repo.config().value<QString>(key);
-
-      git::Remote remote = upstream.remote();
-      QString remoteName = remote.name();
-      QString text = tr("delete '%1' from '%2'").arg(name, remoteName);
-      LogEntry *entry = view->addLogEntry(text, tr("Push"));
-      QFutureWatcher<git::Result> *watcher =
-        new QFutureWatcher<git::Result>(view);
-      RemoteCallbacks *callbacks = new RemoteCallbacks(
-        RemoteCallbacks::Send, entry, remote.url(), remoteName, watcher, repo);
-
-      entry->setBusy(true);
-      QStringList refspecs(QString(":%1").arg(upstreamName));
-      watcher->setFuture(
-        QtConcurrent::run(remote, &git::Remote::push, callbacks, refspecs));
-
-      connect(watcher, &QFutureWatcher<git::Result>::finished, watcher,
-      [entry, watcher, callbacks, remoteName] {
-        entry->setBusy(false);
-        git::Result result = watcher->result();
-        if (callbacks->isCanceled()) {
-          entry->addEntry(LogEntry::Error, tr("Push canceled."));
-        } else if (!result) {
-          QString err = result.errorString();
-          QString fmt = tr("Unable to push to %1 - %2");
-          entry->addEntry(LogEntry::Error, fmt.arg(remoteName, err));
-        }
-
-        watcher->deleteLater();
-      });
-    }
-
-    git::Branch(branch).remove();
+    if (upstream.isValid() && checkBox()->isChecked())
+      view->deleteRemoteBranch(upstream);
   });
 
   remove->setFocus();
 
-  if (!branch.isMerged()) {
+  if (isLocal && !branch.isMerged()) {
     setInformativeText(
       tr("The branch is not fully merged. Deleting "
          "it may cause some commits to be lost."));

--- a/src/dialogs/RemoteDialog.cpp
+++ b/src/dialogs/RemoteDialog.cpp
@@ -89,7 +89,7 @@ RemoteDialog::RemoteDialog(Kind kind, RepoView *parent)
     connect(mRefs, &ReferenceList::referenceSelected,
     [this](const git::Reference &ref) {
       QString value = QString();
-      if (ref.isValid()) {
+      if (ref.isValid() && ref.isLocalBranch() && git::Branch(ref).upstream().isValid()) {
         QString key = QString("branch.%1.merge").arg(ref.name());
         git::Config config = RepoView::parentView(this)->repo().config();
         value = config.value<QString>(key);

--- a/src/git/Remote.cpp
+++ b/src/git/Remote.cpp
@@ -571,7 +571,7 @@ Result Remote::push(
   QString refspec = prefix + src.qualifiedName();
   if (!dst.isEmpty()) {
     refspec += ":" + dst;
-  } else {
+  } else if (src.isLocalBranch() && git::Branch(src).upstream().isValid()) {
     QString key = QString("branch.%1.merge").arg(src.name());
     QString upstream = repo.config().value<QString>(key);
     if (!upstream.isEmpty())

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -505,7 +505,7 @@ void ReferenceView::contextMenuEvent(QContextMenuEvent *event)
     rename->setEnabled(!ref.isHead());
   }
 
-  if (ref.isTag() || ref.isLocalBranch()) {
+  if (ref.isTag() || ref.isBranch()) {
     QAction *remove = menu.addAction(tr("Delete"), [this, ref] {
       if (ref.isTag()) {
         DeleteTagDialog *dialog = new DeleteTagDialog(ref, this);

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -230,6 +230,8 @@ public:
     bool force = false,
     bool tags = false);
 
+  void deleteRemoteBranch(const git::Branch &branch);
+
   // commit
   bool commit(
     const QString &message,


### PR DESCRIPTION
This PR enables `Delete` action (via right-click context menu) for remote branches, in addition to the extra checkbox seen in the Delete Local Branch dialog.

This PR also contains a minor fix for undesirable push behavior (see its commit for details).