### PR TITLE
Fixed menubar shows incorrect in dark theme.

### DIFF
--- a/conf/themes/Dark.lua
+++ b/conf/themes/Dark.lua
@@ -153,8 +153,8 @@ theme['link']      = {
 
 -- menubar background color
 theme['menubar']   = {
-  text             = '#212226',
-  background       = '#F0F0F0'
+  text             = '#F0F0F0',
+  background       = '#212226'
 }
 
 -- tabbar background color (uncomment lines to customize)


### PR DESCRIPTION
Fixed menubar shows incorrect in dark theme.

Before:
![before](https://github.com/gitahead/gitahead/assets/31060590/09a1b7eb-70e5-4ee6-8724-134f5df45be6)

After:
![after](https://github.com/gitahead/gitahead/assets/31060590/8516f00e-d375-498c-b307-2f828be0c2d3)
